### PR TITLE
Added CUDA support

### DIFF
--- a/src/ACE.pri
+++ b/src/ACE.pri
@@ -17,3 +17,13 @@ QMAKE_CXX = mpic++
 DEFINES += QT_DEPRECATED_WARNINGS
 
 CONFIG += c++11
+
+isEmpty($$(CUDADIR)) {
+   CUDADIR = /usr/local/cuda
+}
+else {
+   CUDADIR = $$(CUDADIR)
+}
+
+INCLUDEPATH += $${CUDADIR}/include
+DEPENDPATH += $${CUDADIR}/include

--- a/src/console/ace_settingsrun.cpp
+++ b/src/console/ace_settingsrun.cpp
@@ -113,6 +113,8 @@ QString SettingsRun::cudaDeviceString()
 {
    EDEBUG_FUNC(this)
 
+   // Return the CUDA device setting as a string formatted as the device index.
+   // If no device is set then return "none". 
    QString ret {"none"};
    Ace::Settings& settings {Ace::Settings::instance()};
    int device {settings.cudaDevice()};
@@ -235,6 +237,8 @@ void SettingsRun::setCUDA()
 {
    EDEBUG_FUNC(this)
 
+   // If this object's command argument size is empty then throw an exception, else 
+   // go the next step. 
    auto invalid = [this]()
    {
       E_MAKE_EXCEPTION(e);
@@ -249,6 +253,11 @@ void SettingsRun::setCUDA()
       e.setDetails(QObject::tr("Settings set cuda requires sub argument, exiting..."));
       throw e;
    }
+
+   // Attempt to parse the device index from this object's first command
+   // argument. If the first argument is the special string "none" then set 
+   // the device index to -1 denoting no device. If parsing the first command
+   // argument fails then throw an exception. 
    int device {-1};
    if ( _command.first() != QString("none") )
    {
@@ -263,6 +272,8 @@ void SettingsRun::setCUDA()
          invalid();
       }
    }
+
+   // Set the new device index to ACE global settings. 
    Ace::Settings& settings {Ace::Settings::instance()};
    settings.setCUDADevice(device);
 }
@@ -594,6 +605,7 @@ void SettingsRun::listCUDA()
 {
    EDEBUG_FUNC(this)
 
+   // List all available OpenCL devices to standard output by their index and name. 
    QTextStream stream (stdout);
    for(int d = 0; d < CUDA::Device::size() ;++d)
    {

--- a/src/console/ace_settingsrun.h
+++ b/src/console/ace_settingsrun.h
@@ -22,8 +22,10 @@ namespace Ace
       void execute();
    private:
       void settings();
+      QString cudaDeviceString();
       QString openCLDeviceString();
       void set();
+      void setCUDA();
       void setOpenCL();
       void setThreads();
       void setBuffer();
@@ -32,6 +34,7 @@ namespace Ace
       void setChunkExt();
       void setLogging();
       void list();
+      void listCUDA();
       void listOpenCL();
       /*!
        * The command arguments parsed out of the command line arguments of the main 

--- a/src/core/ace_analytic.h
+++ b/src/core/ace_analytic.h
@@ -15,6 +15,7 @@ namespace Ace
       class SerialRun;
       class Single;
       class OpenCLRun;
+      class CUDARun;
       class Chunk;
       class Merge;
       class AbstractMPI;

--- a/src/core/ace_analytic_abstractmpi.h
+++ b/src/core/ace_analytic_abstractmpi.h
@@ -30,7 +30,7 @@ namespace Ace
          {
             /*!
              * Defines the serial resource which causes a slave node to run in plain serial 
-             * mode with no OpenCL device. 
+             * mode with no acceleration. 
              */
             Serial
             /*!
@@ -38,6 +38,11 @@ namespace Ace
              * OpenCL mode with a given platform and device index. 
              */
             ,OpenCL
+            /*!
+             * Defines the CUDA resource which causes the slave node to run in accelerated 
+             * CUDA mode with a given device index. 
+             */
+            ,CUDA
          };
       protected:
          virtual void mpiStart(Type type, int platform, int device);
@@ -62,6 +67,11 @@ namespace Ace
              * node to signal it is ready to execute work blocks using an OpenCL run object. 
              */
             ,ReadyAsOpenCL = -3
+            /*!
+             * Defines the ready as CUDA code which is sent to the master node by a slave
+             * node to signal it is ready to execute work blocks using a CUDA run object.
+             */
+            ,ReadyAsCUDA = -4
          };
          explicit AbstractMPI(quint16 type);
       protected slots:

--- a/src/core/ace_analytic_chunk.h
+++ b/src/core/ace_analytic_chunk.h
@@ -38,8 +38,9 @@ namespace Ace
       private:
          void setupFile();
          void setupIndexes();
+         bool setupCUDA();
          bool setupOpenCL();
-         void setupSerial();
+         bool setupSerial();
          /*!
           * The chunk index for this chunk manager. 
           */

--- a/src/core/ace_analytic_cudarun.cpp
+++ b/src/core/ace_analytic_cudarun.cpp
@@ -1,0 +1,147 @@
+#include "ace_analytic_cudarun.h"
+#include "ace_analytic_cudarun_thread.h"
+#include "ace_analytic_abstractinput.h"
+#include "ace_settings.h"
+#include "eabstractanalytic_cuda_worker.h"
+#include "eabstractanalytic_block.h"
+#include "cuda_device.h"
+#include "cuda_context.h"
+#include "eexception.h"
+#include "edebug.h"
+
+
+
+using namespace std;
+using namespace Ace::Analytic;
+//
+
+
+
+
+
+
+/*!
+ * Implements the interface that is called to add a work block to be processed by
+ * this abstract run. This implementation waits until a thread is idle and then
+ * adding the given work block to the idle thread for execution. While this waits
+ * it is blocking.
+ *
+ * @param block The work block that is processed.
+ */
+void CUDARun::addWork(std::unique_ptr<EAbstractAnalytic::Block>&& block)
+{
+   EDEBUG_FUNC(this,block.get())
+
+   // Wait until there is at least one idle thread, blocking execution until that is 
+   // the case. 
+   while ( _idle.isEmpty() )
+   {
+      QCoreApplication::processEvents();
+   }
+
+   // Add the given work block to the first idle thread for execution in its own 
+   // thread. 
+   _idle.dequeue()->execute(std::move(block));
+}
+
+
+
+
+
+
+/*!
+ * Constructs a new CUDA run object with the given abstract CUDA object, CUDA
+ * device, abstract input object, and optional parent.
+ *
+ * @param cuda Pointer to the abstract CUDA object used for creation abstract
+ *               CUDA blocks.
+ *
+ * @param device Pointer to the CUDA device utilized by this new CUDA object.
+ *
+ * @param base Pointer to the abstract input object used to save results.
+ *
+ * @param parent Optional parent for this new CUDA run.
+ */
+CUDARun::CUDARun(EAbstractAnalytic::CUDA* cuda, CUDA::Device* device, AbstractInput* base, QObject* parent):
+   AbstractRun(parent),
+   _context(new CUDA::Context(device,this)),
+   _cuda(cuda),
+   _base(base),
+   _threads(Settings::instance().threadSize())
+{
+   EDEBUG_FUNC(this,cuda,device,base,parent)
+
+   // Initialize the given abstract CUDA object, create a qt mapper and connect its 
+   // mapped signal. 
+   cuda->initialize(_context);
+
+   // Iterate through the number of CUDA threads this run object contains, 
+   // initializing each one with a new worker created from the abstract CUDA 
+   // object. Add all threads to the idle queue, the mapper with their given index, 
+   // and connecting their finished signal with this object's block finished slot 
+   // using the mapper to get the index. 
+   for (int i = 0; i < _threads.size() ;++i)
+   {
+      Thread* thread {new Thread(_cuda->makeWorker())};
+      _threads[i] = thread;
+      _idle << thread;
+      connect(thread
+              ,&Thread::blockFinished
+              ,this
+              ,[this,i]{ blockFinished(i); }
+              ,Qt::QueuedConnection);
+      thread->start();
+   }
+}
+
+
+
+
+
+
+/*!
+ * This deletes all threads this CUDA run contains. The threads are not deleted
+ * until their thread has finished execution, blocking until that is the case. This
+ * is to prevent undefined behavior.
+ */
+CUDARun::~CUDARun()
+{
+   EDEBUG_FUNC(this)
+
+   // Iterate through all threads, for each one waiting until it is no longer running 
+   // and then deleting it. 
+   for (auto thread: _threads)
+   {
+      thread->requestInterruption();
+      while ( thread->isRunning() );
+      delete thread;
+   }
+}
+
+
+
+
+
+
+/*!
+ * Called when on of this object's threads has finished execution and contains a
+ * result block.
+ *
+ * @param index
+ */
+void CUDARun::blockFinished(int index)
+{
+   EDEBUG_FUNC(this,index)
+
+   // Get the result block from the thread that finished execution, saving it to this 
+   // object's abstract input and adding the thread to this object's idle queue. 
+   Thread* thread {_threads.at(index)};
+   _base->saveResult(thread->result());
+   _idle.enqueue(thread);
+
+   // If this object's abstract input is finished then emit the finished signal. 
+   if ( _base->isFinished() )
+   {
+      emit finished();
+   }
+}

--- a/src/core/ace_analytic_cudarun.h
+++ b/src/core/ace_analytic_cudarun.h
@@ -1,0 +1,66 @@
+#ifndef ACE_ANALYTIC_CUDARUN_H
+#define ACE_ANALYTIC_CUDARUN_H
+#include <memory>
+#include <QVector>
+#include <QQueue>
+#include "ace_analytic_abstractrun.h"
+#include "ace_analytic.h"
+#include "cuda_common.h"
+#include "eabstractanalytic.h"
+//
+
+
+
+namespace Ace
+{
+   namespace Analytic
+   {
+      /*!
+       * This is a CUDA analytic run that processes the blocks of an analytic using a
+       * CUDA device with multiple threads using the device at once to process work
+       * blocks. This is a complicated analytic run that has its own subclass
+       * representing a thread that actually processes the work blocks into result
+       * blocks.
+       */
+      class CUDARun : public AbstractRun
+      {
+         Q_OBJECT
+      public:
+         virtual void addWork(std::unique_ptr<EAbstractAnalytic::Block>&& block) override final;
+      public:
+         explicit CUDARun(EAbstractAnalytic::CUDA* cuda, CUDA::Device* device, AbstractInput* base, QObject* parent = nullptr);
+         virtual ~CUDARun() override final;
+      private slots:
+         void blockFinished(int index);
+      private:
+         class Thread;
+      private:
+         /*!
+          * Pointer to the CUDA context used by this CUDA run object.
+          */
+         CUDA::Context* _context;
+         /*!
+          * Pointer to the abstract CUDA object used by this object to create abstract
+          * workers for all its threads.
+          */
+         EAbstractAnalytic::CUDA* _cuda;
+         /*!
+          * Pointer to the abstract input object used to save results.
+          */
+         AbstractInput* _base;
+         /*!
+          * Pointer list to all threads this object contains for processing work blocks into
+          * result blocks.
+          */
+         QVector<Thread*> _threads;
+         /*!
+          * Queue of idle threads ready to execute another work block.
+          */
+         QQueue<Thread*> _idle;
+      };
+   }
+}
+
+
+
+#endif

--- a/src/core/ace_analytic_cudarun_thread.cpp
+++ b/src/core/ace_analytic_cudarun_thread.cpp
@@ -1,0 +1,159 @@
+#include "ace_analytic_cudarun_thread.h"
+#include "eabstractanalytic_cuda_worker.h"
+#include "eabstractanalytic_block.h"
+#include "eexception.h"
+#include "edebug.h"
+
+
+
+using namespace std;
+using namespace Ace::Analytic;
+//
+
+
+
+
+
+
+/*!
+ * Constructs a new thread object with the given abstract CUDA worker and
+ * optional parent.
+ *
+ * @param worker An abstract CUDA worker used to do the actual processing of work
+ *               blocks into result blocks.
+ *
+ * @param parent Optional parent of this new thread object.
+ */
+CUDARun::Thread::Thread(std::unique_ptr<EAbstractAnalytic::CUDA::Worker>&& worker, QObject* parent):
+   QThread(parent),
+   _worker(worker.release())
+{
+   EDEBUG_FUNC(this,worker.get(),parent)
+
+   _worker->setParent(this);
+}
+
+
+
+
+
+
+/*!
+ * Executes the processing of the given work block on a separate thread from the
+ * one called this method. This returns immediately after starting the separate
+ * thread. If this thread already contains a result block then an exception is
+ * thrown.
+ *
+ * @param block The work block that is processed on a separate thread.
+ */
+void CUDARun::Thread::execute(std::unique_ptr<EAbstractAnalytic::Block>&& block)
+{
+   EDEBUG_FUNC(this,block.get())
+
+   // If this thread already contains a result block then throw an exception, else go 
+   // to the next step. 
+   if ( _result )
+   {
+      E_MAKE_EXCEPTION(e);
+      e.setTitle(tr("Logic Error"));
+      e.setDetails(tr("Cannot execute CUDA engine piston that contains a result."));
+      throw e;
+   }
+
+   // Delete any previous work block this object contains, set the given work block 
+   // as this objects new work block and then start its separate thread. 
+   delete _work;
+   _work = block.release();
+   _work->setParent(this);
+   ++_switch;
+}
+
+
+
+
+
+
+/*!
+ * Returns the result block produces on this object's separate thread after
+ * finishing. If the separate thread threw an exception that exception is thrown
+ * again on the thread calling this method. If there is not result block an
+ * exception is also thrown.
+ *
+ * @return Result block produced by this object's separate thread execution.
+ */
+std::unique_ptr<EAbstractAnalytic::Block> CUDARun::Thread::result()
+{
+   EDEBUG_FUNC(this)
+
+   // If this object has a saved exception from its separate thread then copy it and 
+   // throw it on this thread, else go to the next step. 
+   if ( _exception )
+   {
+      EException e(*_exception);
+      delete _exception;
+      _exception = nullptr;
+      throw e;
+   }
+
+   // If this object does not contain a result block then throw an exception, else go 
+   // the next step. 
+   if ( !_result )
+   {
+      E_MAKE_EXCEPTION(e);
+      e.setTitle(tr("Logic Error"));
+      e.setDetails(tr("Cannot get result from CUDA engine piston that contains none."));
+      throw e;
+   }
+
+   // Release this object's saved result block from its ownership and return it. 
+   _result->setParent(nullptr);
+   unique_ptr<EAbstractAnalytic::Block> ret {_result};
+   _result = nullptr;
+   return ret;
+}
+
+
+
+
+
+
+/*!
+ * Executes this object's saved work block on its separate thread, saving the
+ * result block. If any exception is thrown within this separate thread it is
+ * caught and saved.
+ */
+void CUDARun::Thread::run()
+{
+   EDEBUG_FUNC(this)
+
+   while (true)
+   {
+      if ( _switch == 1 )
+      {
+         // Process this object's saved work block, saving the result block and 
+         // transferring it to this object's main thread. If any ACE exception occurs then 
+         // catch it and save it. 
+         try
+         {
+            _result = _worker->execute(_work).release();
+            _result->moveToThread(thread());
+            _result->setParent(this);
+         }
+         catch (EException e)
+         {
+            _exception = new EException(e);
+         }
+         --_switch;
+         emit blockFinished();
+      }
+      else if ( isInterruptionRequested() )
+      {
+         return;
+      }
+      usleep(10);
+      if ( _switch == 0 )
+      {
+         msleep(10);
+      }
+   }
+}

--- a/src/core/ace_analytic_cudarun_thread.h
+++ b/src/core/ace_analytic_cudarun_thread.h
@@ -1,0 +1,63 @@
+#ifndef ACE_ANALYTIC_CUDARUN_THREAD_H
+#define ACE_ANALYTIC_CUDARUN_THREAD_H
+#include <QThread>
+#include "ace_analytic_cudarun.h"
+#include "eabstractanalytic_cuda.h"
+#include "global.h"
+//
+
+
+
+namespace Ace
+{
+   namespace Analytic
+   {
+      /*!
+       * This is a single thread of execution used by its parent CUDA run class to
+       * process work blocks into result blocks. The execution of this processing is done
+       * on a separate thread to enhance speed. An abstract CUDA worker object is used
+       * for actual processing using an CUDA device for acceleration.
+       */
+      class CUDARun::Thread : public QThread
+      {
+         Q_OBJECT
+      public:
+         explicit Thread(std::unique_ptr<EAbstractAnalytic::CUDA::Worker>&& worker, QObject* parent = nullptr);
+         void execute(std::unique_ptr<EAbstractAnalytic::Block>&& block);
+         std::unique_ptr<EAbstractAnalytic::Block> result();
+      signals:
+         /*!
+          */
+         void blockFinished();
+      protected:
+         virtual void run() override final;
+      private:
+         /*!
+          */
+         QAtomicInteger<int> _switch {0};
+         /*!
+          * Pointer to the abstract CUDA worker object used to process work blocks into
+          * result blocks using CUDA acceleration.
+          */
+         EAbstractAnalytic::CUDA::Worker* _worker;
+         /*!
+          * Pointer to saved work block, if any, passed along to the separate thread for
+          * processing.
+          */
+         EAbstractAnalytic::Block* _work {nullptr};
+         /*!
+          * Pointer to result block, if any, saved by this object's separate thread.
+          */
+         EAbstractAnalytic::Block* _result {nullptr};
+         /*!
+          * Pointer to any exception that occurs on this object's separate thread while
+          * processing a work block.
+          */
+         EException* _exception {nullptr};
+      };
+   }
+}
+
+
+
+#endif

--- a/src/core/ace_analytic_mpimaster.cpp
+++ b/src/core/ace_analytic_mpimaster.cpp
@@ -163,6 +163,7 @@ void MPIMaster::processCode(int code, int fromRank)
    // serial or OpenCL type. 
    switch (code)
    {
+   case ReadyAsCUDA:
    case ReadyAsOpenCL:
       amount += settings.threadSize() + 1;
       break;

--- a/src/core/ace_analytic_mpislave.cpp
+++ b/src/core/ace_analytic_mpislave.cpp
@@ -347,6 +347,8 @@ bool MPISlave::setupCUDA(int device)
 {
    EDEBUG_FUNC(this)
 
+   // If the given device index is invalid then throw an exception, 
+   // else go to the next step. 
    if ( device < 0 || device >= CUDA::Device::size() )
    {
       E_MAKE_EXCEPTION(e);
@@ -354,6 +356,11 @@ bool MPISlave::setupCUDA(int device)
       e.setDetails(tr("CUDA device %1 does not exist.").arg(device));
       throw e;
    }
+
+   // Attempt to create an abstract analytic CUDA object from this manager's 
+   // analytic. If a valid one is returned then create a new CUDA run object, set 
+   // it to this object, and return true. Else if no valid one is returned then 
+   // return false. 
    bool ret {false};
    if ( EAbstractAnalytic::CUDA* cuda = analytic()->makeCUDA() )
    {

--- a/src/core/ace_analytic_mpislave.h
+++ b/src/core/ace_analytic_mpislave.h
@@ -39,6 +39,7 @@ namespace Ace
       private:
          void processCode(int code);
          void process(const QByteArray& data);
+         bool setupCUDA(int device);
          bool setupOpenCL(int platform, int device);
          void setupSerial();
          /*!

--- a/src/core/ace_analytic_single.cpp
+++ b/src/core/ace_analytic_single.cpp
@@ -3,9 +3,11 @@
 #include "ace_analytic_simplerun.h"
 #include "ace_analytic_serialrun.h"
 #include "ace_analytic_openclrun.h"
+#include "ace_analytic_cudarun.h"
 #include "eabstractanalytic_block.h"
 #include "eabstractanalytic_serial.h"
 #include "eabstractanalytic_opencl.h"
+#include "eabstractanalytic_cuda.h"
 #include "ace_settings.h"
 #include "edebug.h"
 
@@ -110,6 +112,7 @@ void Single::start()
 
    // Setup OpenCL, setup serial if OpenCL fails, and then connect this object's 
    // abstract runner class finished signal with this manager's finish slot. 
+   setupCUDA();
    setupOpenCL();
    setupSerial();
    connect(_runner,&AbstractRun::finished,this,&AbstractManager::finish);
@@ -157,12 +160,43 @@ void Single::process()
 
 
 /*!
+ * Attempts to initialize a CUDA run object for block processing for this
+ * manager. If successful sets this manager's abstract run pointer.
+ */
+void Single::setupCUDA()
+{
+   EDEBUG_FUNC(this)
+
+   Settings& settings {Settings::instance()};
+   if ( settings.cudaDevicePointer() )
+   {
+      EAbstractAnalytic::CUDA* cuda {analytic()->makeCUDA()};
+      if ( cuda )
+      {
+         _runner = new CUDARun(cuda,settings.cudaDevicePointer(),this,this);
+      }
+   }
+}
+
+
+
+
+
+
+/*!
  * Attempts to initialize an OpenCL run object for block processing for this 
  * manager. If successful sets this manager's abstract run pointer. 
  */
 void Single::setupOpenCL()
 {
    EDEBUG_FUNC(this)
+
+   // If this object's abstract run object has already been set then do nothing and 
+   // exit, else go to the next step. 
+   if ( _runner )
+   {
+      return;
+   }
 
    // If the singleton settings object has a valid OpenCL device pointer and this 
    // manager's analytic creates a valid abstract OpenCL object then create a new 
@@ -194,21 +228,22 @@ void Single::setupSerial()
 
    // If this object's abstract run object has already been set then do nothing and 
    // exit, else go to the next step. 
-   if ( !_runner )
+   if ( _runner )
    {
+      return;
+   }
 
-      // If this manager's analytic creates a valid abstract serial object then create a 
-      // new serial run object and set it to this manager's abstract run object, else 
-      // create a new simple run object and set it to this manager's abstract run 
-      // object. 
-      if ( EAbstractAnalytic::Serial* serial = analytic()->makeSerial() )
-      {
-         _runner = new SerialRun(serial,this,this);
-      }
-      else
-      {
-         _runner = new SimpleRun(this,this);
-         _simple = true;
-      }
+   // If this manager's analytic creates a valid abstract serial object then create a 
+   // new serial run object and set it to this manager's abstract run object, else 
+   // create a new simple run object and set it to this manager's abstract run 
+   // object. 
+   if ( EAbstractAnalytic::Serial* serial = analytic()->makeSerial() )
+   {
+      _runner = new SerialRun(serial,this,this);
+   }
+   else
+   {
+      _runner = new SimpleRun(this,this);
+      _simple = true;
    }
 }

--- a/src/core/ace_analytic_single.cpp
+++ b/src/core/ace_analytic_single.cpp
@@ -167,6 +167,9 @@ void Single::setupCUDA()
 {
    EDEBUG_FUNC(this)
 
+   // If the singleton settings object has a valid CUDA device pointer and this 
+   // manager's analytic creates a valid abstract CUDA object then create a new 
+   // CUDA run object, setting this manager's run pointer to the new object. 
    Settings& settings {Settings::instance()};
    if ( settings.cudaDevicePointer() )
    {

--- a/src/core/ace_analytic_single.h
+++ b/src/core/ace_analytic_single.h
@@ -33,6 +33,7 @@ namespace Ace
          virtual void start() override final;
          void process();
       private:
+         void setupCUDA();
          void setupOpenCL();
          void setupSerial();
          /*!

--- a/src/core/ace_settings.cpp
+++ b/src/core/ace_settings.cpp
@@ -295,15 +295,11 @@ int Settings::cudaDevice() const
  * none.
  *
  * @return Pointer to preferred CUDA device or null if none is preferred.
- *
- *
- * Steps of Operation:
- *
- * 1. If the device index is out of range then return a null pointer, else
- *    return a pointer to the device with the device index.
  */
 CUDA::Device* Settings::cudaDevicePointer() const
 {
+   // If the device index is out of range then return a null pointer, else
+   // return a pointer to the device with the device index. 
    if ( _cudaDevice < 0 || _cudaDevice >= CUDA::Device::get(_cudaDevice)->size() )
    {
       return nullptr;
@@ -485,6 +481,8 @@ int Settings::loggingPort() const
  */
 void Settings::setCUDADevice(int index)
 {
+   // If the new given device index is different from the current device index 
+   // then set it to the new one and set the value in persistent storage. 
    if ( index != _cudaDevice )
    {
       _cudaDevice = index;

--- a/src/core/ace_settings.h
+++ b/src/core/ace_settings.h
@@ -1,6 +1,7 @@
 #ifndef ACE_SETTINGS_H
 #define ACE_SETTINGS_H
 #include <QString>
+#include "cuda_common.h"
 #include "opencl.h"
 
 
@@ -33,6 +34,8 @@ namespace Ace
       static int appRevision();
       static void initialize(QString organization, QString application, int majorVersion, int minorVersion, int revision);
       static Settings& instance();
+      int cudaDevice() const;
+      CUDA::Device* cudaDevicePointer() const;
       int openCLPlatform() const;
       int openCLDevice() const;
       OpenCL::Device* openCLDevicePointer() const;
@@ -43,6 +46,7 @@ namespace Ace
       QString chunkExtension() const;
       bool loggingEnabled() const;
       int loggingPort() const;
+      void setCUDADevice(int index);
       void setOpenCLPlatform(int index);
       void setOpenCLDevice(int index);
       void setThreadSize(int size);
@@ -88,6 +92,10 @@ namespace Ace
        */
       static QString _application;
       /*!
+       * The default CUDA device index value.
+       */
+      constexpr static int _cudaDeviceDefault {0};
+      /*!
        * The default OpenCL platform index value. 
        */
       constexpr static int _openCLPlatformDefault {0};
@@ -122,11 +130,15 @@ namespace Ace
        */
       static const int _loggingPortDefault;
       /*!
+       * The qt settings key used to persistently store the CUDA device index value.
+       */
+     static const char* _cudaDeviceKey;
+      /*!
        * The qt settings key used to persistently store the platform index value. 
        */
       static const char* _openCLPlatformKey;
       /*!
-       * The qt settings key used to persistently store the device index value. 
+       * The qt settings key used to persistently store the OpenCL device index value.
        */
       static const char* _openCLDeviceKey;
       /*!
@@ -160,6 +172,10 @@ namespace Ace
        * Points to the global singleton instance of this class. 
        */
       static Settings* _instance;
+      /*!
+       * The index for the preferred CUDA device.
+       */
+      int _cudaDevice;
       /*!
        * The platform index for the preferred OpenCL device. 
        */

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -9,6 +9,7 @@
 #include "eabstractanalytic_input.h"
 #include "eabstractanalytic_serial.h"
 #include "eabstractanalytic_opencl_worker.h"
+#include "eabstractanalytic_cuda_worker.h"
 #include "eabstractdata.h"
 #include "edatastream.h"
 #include "emetadata.h"

--- a/src/core/core.pro
+++ b/src/core/core.pro
@@ -33,12 +33,15 @@ SOURCES += \
     opencl_commandqueue.cpp \
     opencl_kernel.cpp \
     eabstractanalytic_opencl.cpp \
+    eabstractanalytic_cuda.cpp \
     eabstractanalytic_block.cpp \
     opencl_kernel_locker.cpp \
     ace_analytic_simplerun.cpp \
     ace_analytic_serialrun.cpp \
     ace_analytic_openclrun.cpp \
     ace_analytic_openclrun_thread.cpp \
+    ace_analytic_cudarun.cpp \
+    ace_analytic_cudarun_thread.cpp \
     ace_analytic_single.cpp \
     ace_settings.cpp \
     ace_analytic_mpimaster.cpp \
@@ -49,11 +52,19 @@ SOURCES += \
     ace_analytic_abstractinput.cpp \
     ace_analytic_abstractmanager.cpp \
     eabstractanalytic_opencl_worker.cpp \
+    eabstractanalytic_cuda_worker.cpp \
     ace_analytic_abstractmpi.cpp \
     ace_logserver.cpp \
     elog.cpp \
     edebug.cpp \
-    ace_logserver_thread.cpp
+    ace_logserver_thread.cpp \
+    cuda_common.cpp \
+    cuda_context.cpp \
+    cuda_device.cpp \
+    cuda_event.cpp \
+    cuda_kernel.cpp \
+    cuda_program.cpp \
+    cuda_stream.cpp
 
 HEADERS += \
     opencl.h \
@@ -91,13 +102,17 @@ HEADERS += \
     opencl_buffer.h \
     opencl_kernel.h \
     eabstractanalytic_opencl.h \
+    eabstractanalytic_cuda.h \
     opencl_kernel_locker.h \
     ace_analytic_simplerun.h \
     ace_analytic_serialrun.h \
     ace_analytic_openclrun.h \
     ace_analytic_openclrun_thread.h \
+    ace_analytic_cudarun.h \
+    ace_analytic_cudarun_thread.h \
     ace_analytic_single.h \
     eabstractanalytic_opencl_worker.h \
+    eabstractanalytic_cuda_worker.h \
     openclxx.h \
     ace_settings.h \
     ace_analytic_mpimaster.h \
@@ -111,7 +126,16 @@ HEADERS += \
     ace_logserver.h \
     elog.h \
     edebug.h \
-    ace_logserver_thread.h
+    ace_logserver_thread.h \
+    cuda_buffer.h \
+    cuda_common.h \
+    cuda_context.h \
+    cuda_device.h \
+    cuda_event.h \
+    cuda_kernel.h \
+    cuda_program.h \
+    cuda_stream.h \
+    cudaxx.h
 
 isEmpty(PREFIX) { PREFIX = /usr/local }
 library.path = $${PREFIX}/lib

--- a/src/core/cuda_buffer.h
+++ b/src/core/cuda_buffer.h
@@ -1,0 +1,264 @@
+#ifndef CUDA_BUFFER_H
+#define CUDA_BUFFER_H
+#include "cuda_common.h"
+#include "cuda_event.h"
+#include "cuda_stream.h"
+
+
+
+namespace CUDA
+{
+   /*!
+    * This can contain an CUDA buffer object or be set to null. The buffer this
+    * class contains can be moved to another instance but not copied. This is a
+    * template class to enforce strong type checking of the underlying buffer data.
+    *
+    * @tparam T The type used to create the buffer data of this object.
+    */
+   template<class T> class Buffer
+   {
+   public:
+      /*!
+       * Constructs a new buffer object that is set to null.
+       */
+      Buffer() = default;
+      Buffer(int size);
+      Buffer(Buffer<T>&& other);
+      ~Buffer();
+      void operator=(Buffer<T>&& other);
+      T& operator[](int index);
+      const T& at(int index) const;
+      bool isNull() const;
+      CUdeviceptr deviceData() { return _dev; }
+      T* hostData() { return _host; }
+      int size() const { return _size; }
+      Event read(const Stream& stream = Stream::getDefaultStream());
+      Event write(const Stream& stream = Stream::getDefaultStream());
+   private:
+      void clear();
+      void nullify();
+
+      CUdeviceptr _dev {0};
+      T* _host {nullptr};
+      int _size {-1};
+   };
+
+
+
+
+
+
+   /*!
+    * Constructs a new buffer object set to a new CUDA buffer with the given size.
+    *
+    * @param size The size of the buffer created as the number of elements of the
+    *             template type defined.
+    */
+   template<class T> Buffer<T>::Buffer(int size):
+      _size(size)
+   {
+      CUDA_SAFE_CALL(cuMemAllocHost((void**) &_host, size * sizeof(T)));
+      CUDA_SAFE_CALL(cuMemAlloc(&_dev, size * sizeof(T)));
+   }
+
+
+
+
+
+
+   /*!
+    * Constructs a new buffer object taking the state of the other given buffer
+    * object.
+    *
+    * @param other The other buffer object whose state, null or set to an CUDA
+    *              buffer, is taken by this new buffer object.
+    */
+   template<class T> Buffer<T>::Buffer(Buffer<T>&& other):
+      _dev(other._dev),
+      _host(other._host),
+      _size(other._size)
+   {
+      other.nullify();
+   }
+
+
+
+
+
+
+   /*!
+    * Clears all resources this buffer object may contain.
+    */
+   template<class T> Buffer<T>::~Buffer()
+   {
+      clear();
+   }
+
+
+
+
+
+
+   /*!
+    * Takes the state of the given buffer object , null or set to a CUDA buffer,
+    * overwriting and clearing any CUDA buffer this object may already contain.
+    *
+    * @param other The other buffer object whose state, null or set to an CUDA
+    *              buffer, is taken by this buffer object.
+    */
+   template<class T> void Buffer<T>::operator=(Buffer<T>&& other)
+   {
+      clear();
+      _dev = other._dev;
+      _host = other._host;
+      _size = other._size;
+      other.nullify();
+   }
+
+
+
+
+
+
+   template<class T> T& Buffer<T>::operator[](int index)
+   {
+      if ( !_host )
+      {
+         E_MAKE_EXCEPTION(e);
+         e.setTitle(QObject::tr("Logic Error"));
+         e.setDetails(QObject::tr("Cannot access data from unmapped CUDA buffer."));
+         throw e;
+      }
+      if ( index < 0 || index >= _size )
+      {
+         E_MAKE_EXCEPTION(e);
+         e.setTitle(QObject::tr("Out Of Range"));
+         e.setDetails(QObject::tr("The index %1 is out of range for this CUDA buffer (%2 size).")
+                      .arg(index)
+                      .arg(_size));
+         throw e;
+      }
+      return _host[index];
+   }
+
+
+
+
+
+
+   template<class T> const T& Buffer<T>::at(int index) const
+   {
+      if ( !_host )
+      {
+         E_MAKE_EXCEPTION(e);
+         e.setTitle(QObject::tr("Logic Error"));
+         e.setDetails(QObject::tr("Cannot access data from unmapped CUDA buffer."));
+         throw e;
+      }
+      if ( index < 0 || index >= _size )
+      {
+         E_MAKE_EXCEPTION(e);
+         e.setTitle(QObject::tr("Out Of Range"));
+         e.setDetails(QObject::tr("The index %1 is out of range for this CUDA buffer (%2 size).")
+                      .arg(index)
+                      .arg(_size));
+         throw e;
+      }
+      return _host[index];
+   }
+
+
+
+
+
+
+   template<class T> bool Buffer<T>::isNull() const
+   {
+      return !_dev;
+   }
+
+
+
+
+
+
+   template<class T> Event Buffer<T>::read(const Stream& stream)
+   {
+      if ( !_dev )
+      {
+         E_MAKE_EXCEPTION(e);
+         e.setTitle(QObject::tr("Logic Error"));
+         e.setDetails(QObject::tr("Cannot read from CUDA buffer that is null."));
+         throw e;
+      }
+
+      // copy buffer from device to host
+      CUDA_SAFE_CALL(cuMemcpyDtoHAsync(_host, _dev, _size * sizeof(T), stream.id()));
+
+      // return CUDA event of memcpy
+      Event event;
+      event.record(stream);
+
+      return event;
+   }
+
+
+
+
+
+
+   template<class T> Event Buffer<T>::write(const Stream& stream)
+   {
+      if ( !_dev )
+      {
+         E_MAKE_EXCEPTION(e);
+         e.setTitle(QObject::tr("Logic Error"));
+         e.setDetails(QObject::tr("Cannot write to CUDA buffer that is null."));
+         throw e;
+      }
+
+      // copy buffer from host to device
+      CUDA_SAFE_CALL(cuMemcpyHtoDAsync(_dev, _host, _size * sizeof(T), stream.id()));
+
+      // return CUDA event of memcpy
+      Event event;
+      event.record(stream);
+      
+      return event;
+   }
+
+
+
+
+
+
+   /*!
+    * Release all memory resources. This does not set
+    * any of this object's pointers to null.
+    */
+   template<class T> void Buffer<T>::clear()
+   {
+      CUDA_SAFE_CALL(cuMemFreeHost(_host));
+      CUDA_SAFE_CALL(cuMemFree(_dev));
+   }
+
+
+
+
+
+
+   /*!
+    * Sets this object to a null state by changing all its pointers to null. This does
+    * not free any allocated memory those pointers may be pointing to.
+    */
+   template<class T> void Buffer<T>::nullify()
+   {
+      _dev = 0;
+      _host = nullptr;
+      _size = -1;
+   }
+}
+
+
+
+#endif

--- a/src/core/cuda_buffer.h
+++ b/src/core/cuda_buffer.h
@@ -57,7 +57,7 @@ namespace CUDA
    template<class T> Buffer<T>::Buffer(int size):
       _size(size)
    {
-      CUDA_SAFE_CALL(cuMemAllocHost((void**) &_host, size * sizeof(T)));
+      CUDA_SAFE_CALL(cuMemAllocHost(reinterpret_cast<void**>(&_host), size * sizeof(T)));
       CUDA_SAFE_CALL(cuMemAlloc(&_dev, size * sizeof(T)));
    }
 

--- a/src/core/cuda_common.cpp
+++ b/src/core/cuda_common.cpp
@@ -2,13 +2,19 @@
 
 
 
+//
+
+
+
 
 
 
 /*!
- * Get CUDA error name, if any.
+ * Get the name of a CUDA error code.
  *
- * @param error
+ * @param error CUDA error code.
+ *
+ * @return The name of the given error code.
  */
 QString CUDA::getErrorName(CUresult error)
 {
@@ -24,9 +30,11 @@ QString CUDA::getErrorName(CUresult error)
 
 
 /*!
- * Get CUDA error description, if any.
+ * Get the description of a CUDA error code.
  *
- * @param error
+ * @param error CUDA error code.
+ *
+ * @return The description of the given error code.
  */
 QString CUDA::getErrorString(CUresult error)
 {
@@ -42,11 +50,13 @@ QString CUDA::getErrorString(CUresult error)
 
 
 /*!
- * Get NVRTC error description, if any.
+ * Get the description of a NVRTC error code.
  *
- * @param result
+ * @param error NVRTC error code.
+ *
+ * @return The description of the given error code.
  */
-QString CUDA::getErrorString(nvrtcResult result)
+QString CUDA::getErrorString(nvrtcResult error)
 {
-   return nvrtcGetErrorString(result);
+   return nvrtcGetErrorString(error);
 }

--- a/src/core/cuda_common.cpp
+++ b/src/core/cuda_common.cpp
@@ -1,0 +1,52 @@
+#include "cuda_common.h"
+
+
+
+
+
+
+/*!
+ * Get CUDA error name, if any.
+ *
+ * @param error
+ */
+QString CUDA::getErrorName(CUresult error)
+{
+   const char *str;
+   cuGetErrorName(error, &str);
+
+   return QString(str);
+}
+
+
+
+
+
+
+/*!
+ * Get CUDA error description, if any.
+ *
+ * @param error
+ */
+QString CUDA::getErrorString(CUresult error)
+{
+   const char *str;
+   cuGetErrorString(error, &str);
+
+   return QString(str);
+}
+
+
+
+
+
+
+/*!
+ * Get NVRTC error description, if any.
+ *
+ * @param result
+ */
+QString CUDA::getErrorString(nvrtcResult result)
+{
+   return nvrtcGetErrorString(result);
+}

--- a/src/core/cuda_common.h
+++ b/src/core/cuda_common.h
@@ -1,0 +1,72 @@
+#ifndef CUDA_COMMON_H
+#define CUDA_COMMON_H
+#include <cuda.h>
+#include <nvrtc.h>
+#include <vector_types.h>
+#include "eexception.h"
+#include "global.h"
+
+
+
+#define CUDA_THROW_ERROR(error)           \
+   E_MAKE_EXCEPTION(e);                   \
+   e.setTitle(QObject::tr("CUDA Error")); \
+   e.setDetails(QObject::tr("%1: %2.")    \
+      .arg(getErrorName(error))           \
+      .arg(getErrorString(error)));       \
+   throw e;
+
+
+
+#define CUDA_SAFE_CALL(result)  \
+{                               \
+   CUresult error = (result);   \
+   if ( error != CUDA_SUCCESS ) \
+   {                            \
+      CUDA_THROW_ERROR(error);  \
+   }                            \
+}
+
+
+
+#define NVRTC_THROW_ERROR(error)          \
+   E_MAKE_EXCEPTION(e);                   \
+   e.setTitle(QObject::tr("CUDA Error")); \
+   e.setDetails(QObject::tr("%1: %2.")    \
+      .arg("NVRTC error")                 \
+      .arg(getErrorString(error)));       \
+   throw e;
+
+
+
+#define NVRTC_SAFE_CALL(result)  \
+{                                \
+   nvrtcResult error = (result); \
+   if ( error != NVRTC_SUCCESS ) \
+   {                             \
+      NVRTC_THROW_ERROR(error);  \
+   }                             \
+}
+
+
+
+/*!
+ * This contains all classes and functions associated with using CUDA in ACE.
+ */
+namespace CUDA
+{
+   class Device;
+   class Context;
+   class Program;
+   class Stream;
+   class Event;
+   class Kernel;
+
+   QString getErrorName(CUresult error);
+   QString getErrorString(CUresult error);
+   QString getErrorString(nvrtcResult result);
+}
+
+
+
+#endif

--- a/src/core/cuda_common.h
+++ b/src/core/cuda_common.h
@@ -5,6 +5,7 @@
 #include <vector_types.h>
 #include "eexception.h"
 #include "global.h"
+//
 
 
 

--- a/src/core/cuda_context.cpp
+++ b/src/core/cuda_context.cpp
@@ -4,6 +4,7 @@
 
 
 using namespace CUDA;
+//
 
 
 
@@ -11,13 +12,18 @@ using namespace CUDA;
 
 
 /*!
- * Constructs a new CUDA context with the given device.
+ * Constructs a new CUDA context with the given device and optional parent.
  *
- * @param device
+ * @param device Pointer to the device from which this context is created.
+ *
+ * @param parent Optional parent for this new context. 
  */
 Context::Context(Device* device, QObject* parent):
    QObject(parent)
 {
+   // Create a new CUDA context with the given device, setting this object's CUDA
+   // context ID to the one returned. If creating the context fails then throw
+   // an exception.
    CUDA_SAFE_CALL(cuCtxCreate(&_id, 0, device->id()));
 }
 

--- a/src/core/cuda_context.cpp
+++ b/src/core/cuda_context.cpp
@@ -1,0 +1,48 @@
+#include "cuda_context.h"
+#include "cuda_device.h"
+
+
+
+using namespace CUDA;
+
+
+
+
+
+
+/*!
+ * Constructs a new CUDA context with the given device.
+ *
+ * @param device
+ */
+Context::Context(Device* device, QObject* parent):
+   QObject(parent)
+{
+   CUDA_SAFE_CALL(cuCtxCreate(&_id, 0, device->id()));
+}
+
+
+
+
+
+
+/*!
+ * Releases the underlying CUDA context that this object represents.
+ */
+Context::~Context()
+{
+   cuCtxDestroy(_id);
+}
+
+
+
+
+
+
+/*!
+ * Binds the CUDA context to the current thread.
+ */
+void Context::setCurrent() const
+{
+   CUDA_SAFE_CALL(cuCtxSetCurrent(_id));
+}

--- a/src/core/cuda_context.h
+++ b/src/core/cuda_context.h
@@ -1,0 +1,29 @@
+#ifndef CUDA_CONTEXT_H
+#define CUDA_CONTEXT_H
+#include <QObject>
+#include "cuda_common.h"
+
+
+
+namespace CUDA
+{
+   /*!
+    * This contains a CUDA context. Unlike OpenCL, in which the context is
+    * the top-level object, a CUDA context is created per device per process.
+    */
+   class Context : public QObject
+   {
+      Q_OBJECT
+   public:
+      explicit Context(Device* device, QObject* parent = nullptr);
+      virtual ~Context() override final;
+      CUcontext id() const { return _id; }
+      void setCurrent() const;
+   private:
+      CUcontext _id;
+   };
+}
+
+
+
+#endif

--- a/src/core/cuda_device.cpp
+++ b/src/core/cuda_device.cpp
@@ -107,7 +107,8 @@ QString Device::name() const
 
 
 /*!
- * Returns an attribute of this device. 
+ * Returns an attribute of this device. Refer to the CUDA Toolkit Documentation
+ * for more information on the available kernel attributes.
  *
  * @param attribute Enumerated value for a CUDA device attribute.
  *

--- a/src/core/cuda_device.cpp
+++ b/src/core/cuda_device.cpp
@@ -1,0 +1,146 @@
+#include "cuda_device.h"
+
+
+
+using namespace CUDA;
+
+
+
+
+
+
+/*!
+ * Global list of CUDA devices that are available on this system.
+ */
+QList<CUDA::Device*>* Device::_devices {nullptr};
+
+
+
+
+
+
+/*!
+ * Returns the number of available CUDA devices.
+ */
+int Device::size()
+{
+   populate();
+   return _devices->size();
+}
+
+
+
+
+
+
+/*!
+ * Returns a reference to the CUDA device with the given index. If the index is
+ * out of range an exception is thrown.
+ *
+ * @param index
+ */
+CUDA::Device* Device::get(int index)
+{
+   populate();
+   if ( index < 0 || index >= _devices->size() )
+   {
+      E_MAKE_EXCEPTION(e);
+      e.setTitle(QObject::tr("Out Of Range"));
+      e.setDetails(QObject::tr("CUDA device index %1 is out of range (%2 devices exist).")
+                   .arg(index)
+                   .arg(_devices->size()));
+      throw e;
+   }
+   return _devices->at(index);
+}
+
+
+
+
+
+
+Device::Device(int ordinal)
+{
+   CUDA_SAFE_CALL(cuDeviceGet(&_id, ordinal));
+}
+
+
+
+
+
+
+/*!
+ * Get the name of a CUDA device.
+ */
+QString Device::name() const
+{
+   char name[256];
+   CUDA_SAFE_CALL(cuDeviceGetName(name, sizeof(name), _id));
+
+   return QString(name);
+}
+
+
+
+
+
+
+/*!
+ * Get an attribute of a CUDA device.
+ *
+ * @param attribute
+ */
+int Device::getAttribute(CUdevice_attribute attribute) const
+{
+   int value;
+   CUDA_SAFE_CALL(cuDeviceGetAttribute(&value, attribute, _id));
+
+   return value;
+}
+
+
+
+
+
+
+/*!
+ * Get the global memory size of a CUDA device in bytes.
+ */
+size_t Device::getGlobalMemorySize() const
+{
+   size_t bytes;
+   CUDA_SAFE_CALL(cuDeviceTotalMem(&bytes, _id));
+
+   return bytes;
+}
+
+
+
+
+
+
+/*!
+ * Populates the global list of CUDA devices if it has not already been
+ * populated.
+ */
+void Device::populate()
+{
+   if ( !_devices )
+   {
+      // initialize CUDA Driver API
+      CUDA_SAFE_CALL(cuInit(0));
+
+      // initialize device list
+      _devices = new QList<Device*>();
+
+      // get device count
+      int count;
+      CUDA_SAFE_CALL(cuDeviceGetCount(&count));
+
+      // populate device list
+      for ( int i = 0; i < count; ++i )
+      {
+         *_devices << new Device(i);
+      }
+   }
+}

--- a/src/core/cuda_device.h
+++ b/src/core/cuda_device.h
@@ -7,7 +7,11 @@
 namespace CUDA
 {
    /*!
-    * This provides information about a single CUDA device.
+    * This provides information about a single CUDA device along with static
+    * methods for iterating through all available CUDA devices. This class is not
+    * intended to be instantiated on its own but instead queried through the
+    * static methods. Any device pointer returned by the statics will exist for
+    * the lifetime of the ACE program.
     */
    class Device
    {
@@ -21,7 +25,13 @@ namespace CUDA
       size_t getGlobalMemorySize() const;
    private:
       static void populate();
+      /*!
+       * Global pointer list of CUDA devices that are available on this system.
+       */
       static QList<CUDA::Device*>* _devices;
+      /*!
+       * CUDA device ID for this device.
+       */
       CUdevice _id;
    };
 }

--- a/src/core/cuda_device.h
+++ b/src/core/cuda_device.h
@@ -1,0 +1,31 @@
+#ifndef CUDA_DEVICE_H
+#define CUDA_DEVICE_H
+#include "cuda_common.h"
+
+
+
+namespace CUDA
+{
+   /*!
+    * This provides information about a single CUDA device.
+    */
+   class Device
+   {
+   public:
+      static int size();
+      static CUDA::Device* get(int index);
+      Device(int ordinal);
+      CUdevice id() const { return _id; }
+      QString name() const;
+      int getAttribute(CUdevice_attribute attribute) const;
+      size_t getGlobalMemorySize() const;
+   private:
+      static void populate();
+      static QList<CUDA::Device*>* _devices;
+      CUdevice _id;
+   };
+}
+
+
+
+#endif

--- a/src/core/cuda_event.cpp
+++ b/src/core/cuda_event.cpp
@@ -88,18 +88,18 @@ void Event::wait() const
 bool Event::isDone() const
 {
    // query event status
-   CUresult error = cuEventQuery(_id);
-   if ( error == CUDA_SUCCESS )
+   CUresult result = cuEventQuery(_id);
+   if ( result == CUDA_SUCCESS )
    {
       return true;
    }
-   else if ( error == CUDA_ERROR_NOT_READY )
+   else if ( result == CUDA_ERROR_NOT_READY )
    {
       return false;
    }
    else
    {
-      CUDA_THROW_ERROR(error);
+      CUDA_THROW_ERROR(result);
    }
 }
 

--- a/src/core/cuda_event.cpp
+++ b/src/core/cuda_event.cpp
@@ -3,14 +3,20 @@
 
 
 using namespace CUDA;
+//
 
 
 
 
 
 
+/*!
+ * Constructs a new event.
+ */
 Event::Event()
 {
+   // Create a new event and assign it to this object's state. If creation fails
+   // then throw an exception.
    CUDA_SAFE_CALL(cuEventCreate(&_id, CU_EVENT_DEFAULT));
 }
 
@@ -19,6 +25,12 @@ Event::Event()
 
 
 
+/*!
+ * Constructs a new event taking the CUDA event or null state of the given event.
+ *
+ * @param other The other event object whose data is taken and set to this new 
+ *              event.
+ */
 Event::Event(Event&& other):
    _id(other._id)
 {
@@ -30,8 +42,13 @@ Event::Event(Event&& other):
 
 
 
+/*!
+ * Releases the underlying CUDA event.
+ */
 Event::~Event()
 {
+   // Destroy this event object's state. If this command fails then throw an
+   // exception.
    CUDA_SAFE_CALL(cuEventDestroy(_id));
 }
 
@@ -40,8 +57,17 @@ Event::~Event()
 
 
 
+/*!
+ * Takes the CUDA event or null state of the given event object releasing any
+ * CUDA event this event may currently contain.
+ *
+ * @param other The other event object whose CUDA event or null state is taken.
+ */
 Event& Event::operator=(Event&& other)
 {
+   // Take the state of the other event object and give it the state of this
+   // event object. The former state of this event object will be properly
+   // destroyed with the other object.
    std::swap(_id, other._id);
    return *this;
 }
@@ -52,12 +78,16 @@ Event& Event::operator=(Event&& other)
 
 
 /*!
- * Record the contents of a CUDA stream into a CUDA event.
+ * Records the contents of a CUDA stream into this event. After calling this
+ * method, this event will not be done until the commands currently enqueued in
+ * the given stream are completed.
  *
- * @param stream
+ * @param stream CUDA stream to record.
  */
 void Event::record(const Stream& stream)
 {
+   // Record the contents of the given stream to this event. If this command
+   // fails then throw an exception.
    CUDA_SAFE_CALL(cuEventRecord(_id, stream.id()));
 }
 
@@ -72,6 +102,8 @@ void Event::record(const Stream& stream)
  */
 void Event::wait() const
 {
+   // Wait for this object's event to complete. If waiting fails then throw an
+   // exception.
    CUDA_SAFE_CALL(cuEventSynchronize(_id));
 }
 
@@ -87,7 +119,8 @@ void Event::wait() const
  */
 bool Event::isDone() const
 {
-   // query event status
+   // Get the status of this object's event. If this command returns a valid
+   // status code then return true or false, otherwise throw an exception.
    CUresult result = cuEventQuery(_id);
    if ( result == CUDA_SUCCESS )
    {
@@ -111,11 +144,16 @@ bool Event::isDone() const
 /*!
  * Get the elapsed time (ms) between two CUDA events.
  *
- * @param start
- * @param end
+ * @param start First CUDA event.
+ *
+ * @param end Second CUDA event.
+ *
+ * @return The elapsed time (ms) between the two events.
  */
 float Event::getElapsedTime(Event& start, Event& end)
 {
+   // Get the elapsed time (ms) between the two given events. If this command
+   // fails then throw an exception.
    float ms;
    CUDA_SAFE_CALL(cuEventElapsedTime(&ms, start._id, end._id));
 

--- a/src/core/cuda_event.cpp
+++ b/src/core/cuda_event.cpp
@@ -1,0 +1,123 @@
+#include "cuda_event.h"
+
+
+
+using namespace CUDA;
+
+
+
+
+
+
+Event::Event()
+{
+   CUDA_SAFE_CALL(cuEventCreate(&_id, CU_EVENT_DEFAULT));
+}
+
+
+
+
+
+
+Event::Event(Event&& other):
+   _id(other._id)
+{
+   other._id = nullptr;
+}
+
+
+
+
+
+
+Event::~Event()
+{
+   CUDA_SAFE_CALL(cuEventDestroy(_id));
+}
+
+
+
+
+
+
+Event& Event::operator=(Event&& other)
+{
+   std::swap(_id, other._id);
+   return *this;
+}
+
+
+
+
+
+
+/*!
+ * Record the contents of a CUDA stream into a CUDA event.
+ *
+ * @param stream
+ */
+void Event::record(const Stream& stream)
+{
+   CUDA_SAFE_CALL(cuEventRecord(_id, stream.id()));
+}
+
+
+
+
+
+
+/*!
+ * Waits for this object's CUDA event to complete, blocking until it does. If
+ * this event is null then this returns immediately.
+ */
+void Event::wait() const
+{
+   CUDA_SAFE_CALL(cuEventSynchronize(_id));
+}
+
+
+
+
+
+
+/*!
+ * Tests if this object's CUDA event is complete.
+ *
+ * @return True if this event is complete or null, otherwise false.
+ */
+bool Event::isDone() const
+{
+   // query event status
+   CUresult error = cuEventQuery(_id);
+   if ( error == CUDA_SUCCESS )
+   {
+      return true;
+   }
+   else if ( error == CUDA_ERROR_NOT_READY )
+   {
+      return false;
+   }
+   else
+   {
+      CUDA_THROW_ERROR(error);
+   }
+}
+
+
+
+
+
+
+/*!
+ * Get the elapsed time (ms) between two CUDA events.
+ *
+ * @param start
+ * @param end
+ */
+float Event::getElapsedTime(Event& start, Event& end)
+{
+   float ms;
+   CUDA_SAFE_CALL(cuEventElapsedTime(&ms, start._id, end._id));
+
+   return ms;
+}

--- a/src/core/cuda_event.h
+++ b/src/core/cuda_event.h
@@ -1,0 +1,33 @@
+#ifndef CUDA_EVENT_H
+#define CUDA_EVENT_H
+#include "cuda_common.h"
+#include "cuda_stream.h"
+
+
+
+namespace CUDA
+{
+   /*!
+    * This can contain a CUDA event or be set to null.
+    */
+   class Event
+   {
+   public:
+      Event();
+      Event(const Event& other) = delete;
+      Event(Event&& other);
+      ~Event();
+      Event& operator=(Event&& other);
+      CUevent id() const { return _id; }
+      void record(const Stream& stream);
+      void wait() const;
+      bool isDone() const;
+      static float getElapsedTime(Event& start, Event& end);
+   private:
+      CUevent _id {nullptr};
+   };
+}
+
+
+
+#endif

--- a/src/core/cuda_event.h
+++ b/src/core/cuda_event.h
@@ -8,7 +8,12 @@
 namespace CUDA
 {
    /*!
-    * This can contain a CUDA event or be set to null.
+    * This can contain a CUDA event or be set to null. Event objects may be moved
+    * but not copied. The primary way to use a CUDA event is to create a new event
+    * and then "record" a stream on the event. Doing so will cause the event to
+    * not be done until the currently enqueued commands on that stream are also
+    * done. This class also provides utility methods for testing or waiting on
+    * its event, along with measuring the elapsed time between two events.
     */
    class Event
    {
@@ -24,6 +29,9 @@ namespace CUDA
       bool isDone() const;
       static float getElapsedTime(Event& start, Event& end);
    private:
+      /*!
+       * CUDA event ID of this object or null of this object is uninitialized. 
+       */
       CUevent _id {nullptr};
    };
 }

--- a/src/core/cuda_kernel.cpp
+++ b/src/core/cuda_kernel.cpp
@@ -1,0 +1,81 @@
+#include "cuda_kernel.h"
+#include "cuda_event.h"
+#include "cuda_program.h"
+
+
+
+using namespace CUDA;
+
+
+
+
+
+
+Kernel::Kernel(Program* program, const QString& name)
+{
+   CUDA_SAFE_CALL(cuModuleGetFunction(&_kernel, program->id(), name.toLatin1().data()));
+}
+
+
+
+
+
+
+/*!
+ * Execute kernel on a CUDA stream.
+ *
+ * @param stream
+ */
+Event Kernel::execute(const Stream& stream)
+{
+   // launch kernel
+   CUDA_SAFE_CALL(cuLaunchKernel(
+      _kernel,
+      _gridDim.x, _gridDim.y, _gridDim.z,
+      _blockDim.x, _blockDim.y, _blockDim.z,
+      _sharedMemBytes,
+      stream.id(),
+      _args.data(), nullptr));
+
+   // return CUDA event of kernel execution
+   Event event;
+   event.record(stream);
+
+   return event;
+}
+
+
+
+
+
+
+/*!
+ * Get an attribute of a CUDA kernel.
+ *
+ * @param attribute
+ */
+int Kernel::getAttribute(CUfunction_attribute attribute) const
+{
+   int value;
+   CUDA_SAFE_CALL(cuFuncGetAttribute(&value, attribute, _kernel));
+
+   return value;
+}
+
+
+
+
+
+
+/*!
+ * Sets the global and local sizes of the given dimension used for parallel 
+ * execution of this kernel object.
+ *
+ * @param globalSize
+ * @param localSize
+ */
+void Kernel::setSizes(dim3 globalSize, dim3 localSize)
+{
+   _gridDim = globalSize;
+   _blockDim = localSize;
+}

--- a/src/core/cuda_kernel.h
+++ b/src/core/cuda_kernel.h
@@ -1,0 +1,87 @@
+#ifndef CUDA_KERNEL_H
+#define CUDA_KERNEL_H
+#include "cuda_buffer.h"
+#include "cuda_common.h"
+#include "cuda_stream.h"
+
+
+
+namespace CUDA
+{
+   /*!
+    * This contains a CUDA kernel. This class is designed to be inherited and
+    * implemented by specific kernel implementations. This design works to facilitate
+    * separating the more arduous task of setting of a kernel to execute. This way
+    * arguments for a kernel can be abstracted to C++ with easy to understand
+    * arguments for methods. Because of this design most methods to set the kernel
+    * arguments and work sizes are protected and should only be used by a child
+    * inheriting this class.
+    */
+   class Kernel
+   {
+   public:
+      Kernel(Program* program, const QString& name);
+      virtual ~Kernel() {};
+      Event execute(const Stream& stream = Stream::getDefaultStream());
+   protected:
+      int getAttribute(CUfunction_attribute attribute) const;
+      void setSizes(dim3 globalSize, dim3 localSize);
+      template<class T> void setArgument(int index, T value);
+      template<class T> void setBuffer(int index, Buffer<T>* buffer);
+      void setSharedMemory(unsigned int size) { _sharedMemBytes = size; }
+   private:
+      CUfunction _kernel {nullptr};
+      dim3 _gridDim {1};
+      dim3 _blockDim {1};
+      QVector<void*> _args;
+      unsigned int _sharedMemBytes {0};
+   };
+
+
+
+
+
+
+   /*!
+    * Set kernel argument.
+    *
+    * @param index
+    * @param value
+    */
+   template<class T> void Kernel::setArgument(int index, T value)
+   {
+      // expand list to hold argument
+      if ( _args.size() < index + 1 )
+      {
+         _args.resize(index + 1);
+      }
+
+      if ( _args[index] == nullptr )
+      {
+         _args[index] = new T;
+      }
+
+      // set kernel argument
+      *(T*) _args[index] = value;
+   }
+
+
+
+
+
+
+   /*!
+    * Set kernel buffer argument.
+    *
+    * @param index
+    * @param buffer
+    */
+   template<class T> void Kernel::setBuffer(int index, Buffer<T>* buffer)
+   {
+      setArgument(index, buffer->deviceData());
+   }
+}
+
+
+
+#endif

--- a/src/core/cuda_program.cpp
+++ b/src/core/cuda_program.cpp
@@ -1,0 +1,199 @@
+#include "cuda_program.h"
+#include "cuda_kernel.h"
+
+
+
+using namespace CUDA;
+
+
+
+
+
+
+/**
+ * The CUDA pre- and post-strings provide some standard functionality which is
+ * not provided by NVRTC. The text currently includes several math constants, as
+ * well as an 'extern "C"' block for all device functions.
+ */
+const char* CUDA_PRE =
+   "#ifdef NAN                                    \n"
+   "   #undef NAN                                 \n"
+   "#endif                                        \n"
+   "#define NAN __int_as_float(0x7fffffff)        \n"
+   "#ifdef INFINITY                               \n"
+   "   #undef INFINITY                            \n"
+   "#endif                                        \n"
+   "#define INFINITY __int_as_float(0x7f800000)   \n"
+   "#define M_E            2.71828182845904523540 \n"
+   "#define M_LOG2E        1.44269504088896340740 \n"
+   "#define M_LOG10E       0.43429448190325182765 \n"
+   "#define M_LN2          0.69314718055994530942 \n"
+   "#define M_LN10         2.30258509299404568402 \n"
+   "#define M_PI           3.14159265358979323846 \n"
+   "#define M_PI_2         1.57079632679489661923 \n"
+   "#define M_PI_4         0.78539816339744830962 \n"
+   "#define M_1_PI         0.31830988618379067154 \n"
+   "#define M_2_PI         0.63661977236758134308 \n"
+   "#define M_2_SQRTPI     1.12837916709551257390 \n"
+   "#define M_SQRT2        1.41421356237309504880 \n"
+   "#define M_SQRT1_2      0.70710678118654752440 \n"
+   "\n"
+   "extern \"C\" {\n";
+
+
+
+
+
+
+const char* CUDA_POST =
+   "}\n";
+
+
+
+
+
+
+/*!
+ * Construct a new program with the given context, list of CUDA source file paths,
+ * and parent.
+ *
+ * @param paths
+ * @param parent
+ */
+Program::Program(const QStringList& paths, QObject* parent):
+   QObject(parent)
+{
+   // append each source file to program source
+   for ( auto& path : paths )
+   {
+      QString source {readSourceFile(path)};
+      _source.append(source);
+   }
+
+   // insert the CUDA pre- and post-strings
+   _source.prepend(CUDA_PRE);
+   _source.append(CUDA_POST);
+
+   // create new program with source
+   NVRTC_SAFE_CALL(nvrtcCreateProgram(&_program, _source.toLatin1().data(), nullptr, 0, nullptr, nullptr));
+
+   // build program on current context
+   build();
+}
+
+
+
+
+
+
+Program::~Program()
+{
+   // if program exists release it
+   if ( _program )
+   {
+      NVRTC_SAFE_CALL(nvrtcDestroyProgram(&_program));
+   }
+
+   // if module exists unload it
+   if ( _module )
+   {
+      CUDA_SAFE_CALL(cuModuleUnload(_module));
+   }
+}
+
+
+
+
+
+
+/*!
+ * Reads a CUDA kernel source file with the given path. If the source file
+ * fails to open then an exception is thrown.
+ *
+ * @param path
+ */
+QString Program::readSourceFile(const QString& path)
+{
+   // open file
+   QFile file(path);
+   if ( !file.open(QIODevice::ReadOnly) )
+   {
+      E_MAKE_EXCEPTION(e);
+      e.setTitle(QObject::tr("System Error"));
+      e.setDetails(QObject::tr("Failed opening CUDA kernel source code file %1: %2")
+                   .arg(path)
+                   .arg(file.errorString()));
+      throw e;
+   }
+
+   // read entire file and return source
+   QTextStream stream(&file);
+
+   return stream.readAll();
+}
+
+
+
+
+
+
+/*!
+ * Build CUDA program.
+ */
+void Program::build()
+{
+   // compile program
+   const char *options[] = {
+      "--std=c++11",
+#ifdef QT_DEBUG
+      "--device-debug",
+      "--generate-line-info"
+#endif
+   };
+   int numOptions = sizeof(options) / sizeof(char *);
+
+   nvrtcResult result = nvrtcCompileProgram(_program, numOptions, options);
+
+   if ( result == NVRTC_ERROR_COMPILATION )
+   {
+      // if a build error occured while compiling then report build log as error
+      E_MAKE_EXCEPTION(e);
+      e.setTitle(QObject::tr("CUDA Build Failure"));
+      e.setDetails(getBuildLog());
+      throw e;
+   }
+   else if ( result != NVRTC_SUCCESS )
+   {
+      // else another type of error occured and handle normally
+      NVRTC_THROW_ERROR(result);
+   }
+
+   // get PTX source from program
+   size_t ptxSize;
+   NVRTC_SAFE_CALL(nvrtcGetPTXSize(_program, &ptxSize));
+
+   char ptx[ptxSize];
+   NVRTC_SAFE_CALL(nvrtcGetPTX(_program, ptx));
+
+   // load module from PTX source
+   CUDA_SAFE_CALL(cuModuleLoadData(&_module, ptx));
+}
+
+
+
+
+
+
+/*!
+ * Get build log from CUDA program.
+ */
+QString Program::getBuildLog() const
+{
+   size_t logSize;
+   NVRTC_SAFE_CALL(nvrtcGetProgramLogSize(_program, &logSize));
+
+   char log[logSize];
+   NVRTC_SAFE_CALL(nvrtcGetProgramLog(_program, log));
+
+   return QString(log);
+}

--- a/src/core/cuda_program.h
+++ b/src/core/cuda_program.h
@@ -1,0 +1,34 @@
+#ifndef CUDA_PROGRAM_H
+#define CUDA_PROGRAM_H
+#include <QObject>
+#include "cuda_common.h"
+
+
+
+namespace CUDA
+{
+   /*!
+    * This contains a CUDA program. The purpose of this class is to build a
+    * given list of files assumed to be CUDA kernel source code, and to provide
+    * CUDA kernel objects from compiled source code.
+    */
+   class Program : public QObject
+   {
+      Q_OBJECT
+   public:
+      explicit Program(const QStringList& paths, QObject* parent = nullptr);
+      virtual ~Program() override final;
+      CUmodule id() const { return _module; }
+   private:
+      QString readSourceFile(const QString& path);
+      void build();
+      QString getBuildLog() const;
+      nvrtcProgram _program {nullptr};
+      CUmodule _module {nullptr};
+      QString _source;
+   };
+}
+
+
+
+#endif

--- a/src/core/cuda_program.h
+++ b/src/core/cuda_program.h
@@ -23,8 +23,17 @@ namespace CUDA
       QString readSourceFile(const QString& path);
       void build();
       QString getBuildLog() const;
+      /*!
+       * The NVRTC program for this object. 
+       */
       nvrtcProgram _program {nullptr};
+      /*!
+       * The CUDA module for this object. 
+       */
       CUmodule _module {nullptr};
+      /*!
+       * The kernel source code.
+       */
       QString _source;
    };
 }

--- a/src/core/cuda_stream.cpp
+++ b/src/core/cuda_stream.cpp
@@ -1,0 +1,118 @@
+#include "cuda_stream.h"
+#include "cuda_event.h"
+
+
+
+using namespace CUDA;
+
+
+
+
+
+
+Stream::Stream()
+{
+   CUDA_SAFE_CALL(cuStreamCreate(&_id, CU_STREAM_DEFAULT));
+}
+
+
+
+
+
+
+Stream::Stream(Stream&& other)
+   : Stream()
+{
+   std::swap(_id, other._id);
+}
+
+
+
+
+
+
+Stream::~Stream()
+{
+   if ( _id != nullptr )
+   {
+      CUDA_SAFE_CALL(cuStreamDestroy(_id));
+   }
+}
+
+
+
+
+
+
+Stream& Stream::operator=(Stream&& other)
+{
+   std::swap(_id, other._id);
+   return *this;
+}
+
+
+
+
+
+
+/*!
+ * Get the default stream.
+ */
+CUDA::Stream Stream::getDefaultStream()
+{
+   return Stream(nullptr);
+}
+
+
+
+
+
+
+/*!
+ * Block host execution until all operations in stream are complete.
+ */
+void Stream::wait()
+{
+   CUDA_SAFE_CALL(cuStreamSynchronize(_id));
+}
+
+
+
+
+
+
+/*!
+ * Block future stream operations until event is complete.
+ *
+ * @param event
+ */
+void Stream::waitEvent(const Event& event)
+{
+   CUDA_SAFE_CALL(cuStreamWaitEvent(_id, event.id(), 0));
+}
+
+
+
+
+
+
+/*!
+ * Check whether all operations in stream are complete.
+ */
+bool Stream::isDone()
+{
+   // query stream status
+   CUresult error = cuStreamQuery(_id);
+   if ( error == CUDA_SUCCESS )
+   {
+      return true;
+   }
+   else if ( error == CUDA_ERROR_NOT_READY )
+   {
+      return false;
+   }
+   else
+   {
+      CUDA_THROW_ERROR(error);
+   }
+}

--- a/src/core/cuda_stream.cpp
+++ b/src/core/cuda_stream.cpp
@@ -102,17 +102,17 @@ void Stream::waitEvent(const Event& event)
 bool Stream::isDone()
 {
    // query stream status
-   CUresult error = cuStreamQuery(_id);
-   if ( error == CUDA_SUCCESS )
+   CUresult result = cuStreamQuery(_id);
+   if ( result == CUDA_SUCCESS )
    {
       return true;
    }
-   else if ( error == CUDA_ERROR_NOT_READY )
+   else if ( result == CUDA_ERROR_NOT_READY )
    {
       return false;
    }
    else
    {
-      CUDA_THROW_ERROR(error);
+      CUDA_THROW_ERROR(result);
    }
 }

--- a/src/core/cuda_stream.cpp
+++ b/src/core/cuda_stream.cpp
@@ -4,14 +4,19 @@
 
 
 using namespace CUDA;
+//
 
 
 
 
 
 
+/*!
+ * Constructs a new CUDA stream. If a CUDA error occurs then an exception is thrown. 
+ */
 Stream::Stream()
 {
+   // Create a new CUDA stream. If the command fails then throw an exception.
    CUDA_SAFE_CALL(cuStreamCreate(&_id, CU_STREAM_DEFAULT));
 }
 
@@ -20,9 +25,17 @@ Stream::Stream()
 
 
 
+/*!
+ * Constructs a CUDA stream by taking the state from another stream object.
+ *
+ * @param other CUDA stream object whose state is taken.
+ */
 Stream::Stream(Stream&& other)
    : Stream()
 {
+   // Take the state of the other stream object and give it the state of this
+   // object. The previous state of this object will be properly destroyed with
+   // the other stream object.
    std::swap(_id, other._id);
 }
 
@@ -31,6 +44,9 @@ Stream::Stream(Stream&& other)
 
 
 
+/*!
+ * Releases the underlying CUDA stream resource. 
+ */
 Stream::~Stream()
 {
    if ( _id != nullptr )
@@ -44,8 +60,16 @@ Stream::~Stream()
 
 
 
+/*!
+ * Take the state from another stream object.
+ *
+ * @param other CUDA stream object whose state is taken.
+ */
 Stream& Stream::operator=(Stream&& other)
 {
+   // Take the state of the other stream object and give it the state of this
+   // object. The previous state of this object will be properly destroyed with
+   // the other stream object.
    std::swap(_id, other._id);
    return *this;
 }
@@ -56,7 +80,9 @@ Stream& Stream::operator=(Stream&& other)
 
 
 /*!
- * Get the default stream.
+ * Returns a stream object for the default stream.
+ *
+ * @return Stream object for the default stream.
  */
 CUDA::Stream Stream::getDefaultStream()
 {
@@ -69,7 +95,8 @@ CUDA::Stream Stream::getDefaultStream()
 
 
 /*!
- * Block host execution until all operations in stream are complete.
+ * Waits until all operations in this stream are complete. If a CUDA error
+ * occurs then an exception is thrown.
  */
 void Stream::wait()
 {
@@ -82,9 +109,10 @@ void Stream::wait()
 
 
 /*!
- * Block future stream operations until event is complete.
+ * Blocks all future operations on this stream until the given event is complete.
+ * If a CUDA error occurs then an exception is thrown.
  *
- * @param event
+ * @param event CUDA event on which to block this stream.
  */
 void Stream::waitEvent(const Event& event)
 {
@@ -97,11 +125,15 @@ void Stream::waitEvent(const Event& event)
 
 
 /*!
- * Check whether all operations in stream are complete.
+ * Checks whether all operations in this stream are complete. If a CUDA error
+ * occurs then an exception is thrown.
+ *
+ * @return True if all operations in this stream are complete, otherwise false.
  */
 bool Stream::isDone()
 {
-   // query stream status
+   // Get the status of this object's stream. If this command returns a valid
+   // status code then return true or false, otherwise throw an exception.
    CUresult result = cuStreamQuery(_id);
    if ( result == CUDA_SUCCESS )
    {

--- a/src/core/cuda_stream.h
+++ b/src/core/cuda_stream.h
@@ -1,13 +1,18 @@
 #ifndef CUDA_STREAM_H
 #define CUDA_STREAM_H
 #include "cuda_common.h"
+//
 
 
 
 namespace CUDA
 {
    /*!
-    * This contains a CUDA stream.
+    * This contains a CUDA stream. This is a very basic class that simply 
+    * maintains ownership of an underlying stream. The main purpose of this 
+    * class is to be used by other classes that add commands to its underlying
+    * stream. Streams can be moved but not copied. This class also provides a
+    * static method for accessing the default stream.
     */
    class Stream
    {
@@ -25,6 +30,9 @@ namespace CUDA
    private:
       Stream(CUstream id) : _id(id) {}
 
+      /*!
+       * The CUDA stream ID of this object. 
+       */
       CUstream _id {nullptr};
    };
 }

--- a/src/core/cuda_stream.h
+++ b/src/core/cuda_stream.h
@@ -1,0 +1,34 @@
+#ifndef CUDA_STREAM_H
+#define CUDA_STREAM_H
+#include "cuda_common.h"
+
+
+
+namespace CUDA
+{
+   /*!
+    * This contains a CUDA stream.
+    */
+   class Stream
+   {
+   public:
+      Stream();
+      Stream(const Stream&) = delete;
+      Stream(Stream&& move);
+      ~Stream();
+      Stream& operator=(Stream&& move);
+      static Stream getDefaultStream();
+      CUstream id() const { return _id; }
+      void wait();
+      void waitEvent(const Event& event);
+      bool isDone();
+   private:
+      Stream(CUstream id) : _id(id) {}
+
+      CUstream _id {nullptr};
+   };
+}
+
+
+
+#endif

--- a/src/core/cudaxx.h
+++ b/src/core/cudaxx.h
@@ -1,0 +1,10 @@
+#ifndef CUDAXX_H
+#define CUDAXX_H
+#include "cuda_device.h"
+#include "cuda_context.h"
+#include "cuda_program.h"
+#include "cuda_stream.h"
+#include "cuda_event.h"
+#include "cuda_buffer.h"
+#include "cuda_kernel.h"
+#endif

--- a/src/core/eabstractanalytic.cpp
+++ b/src/core/eabstractanalytic.cpp
@@ -126,6 +126,26 @@ EAbstractAnalytic::OpenCL* EAbstractAnalytic::makeOpenCL()
 
 
 /*!
+ * This interface makes a new CUDA object and returns its pointer. If this
+ * analytic type does not support CUDA then a null pointer is returned. The
+ * default implementation returns a null pointer.
+ *
+ * @return Pointer to new CUDA object or null if this analytic does not support
+ *         CUDA.
+ */
+EAbstractAnalytic::CUDA* EAbstractAnalytic::makeCUDA()
+{
+   EDEBUG_FUNC(this)
+
+   return nullptr;
+}
+
+
+
+
+
+
+/*!
  * This interface initializes this analytic. This is called only once before any 
  * other interface is called for this analytic. The default implementation does 
  * nothing. 

--- a/src/core/eabstractanalytic.h
+++ b/src/core/eabstractanalytic.h
@@ -29,6 +29,7 @@ public:
    class Input;
    class Serial;
    class OpenCL;
+   class CUDA;
 public:
    /*!
     * This interface returns the total number of blocks this analytic must process as 
@@ -59,6 +60,7 @@ public:
    virtual std::unique_ptr<EAbstractAnalytic::Block> makeResult() const;
    virtual EAbstractAnalytic::Serial* makeSerial();
    virtual EAbstractAnalytic::OpenCL* makeOpenCL();
+   virtual EAbstractAnalytic::CUDA* makeCUDA();
    virtual void initialize();
    virtual void initializeOutputs();
    virtual void finish();

--- a/src/core/eabstractanalytic_cuda.cpp
+++ b/src/core/eabstractanalytic_cuda.cpp
@@ -1,0 +1,22 @@
+#include "eabstractanalytic_cuda.h"
+#include "edebug.h"
+
+
+
+//
+
+
+
+
+
+
+/*!
+ * Constructs a new abstract CUDA object with the given parent.
+ *
+ * @param parent The parent analytic object for this new CUDA object.
+ */
+EAbstractAnalytic::CUDA::CUDA(EAbstractAnalytic* parent):
+   QObject(parent)
+{
+   EDEBUG_FUNC(this,parent)
+}

--- a/src/core/eabstractanalytic_cuda.h
+++ b/src/core/eabstractanalytic_cuda.h
@@ -1,0 +1,42 @@
+#ifndef EABSTRACTANALYTIC_CUDA_H
+#define EABSTRACTANALYTIC_CUDA_H
+#include "eabstractanalytic.h"
+#include "cuda_common.h"
+//
+
+
+
+/*!
+ * This represents the base CUDA class for an analytic. This class is responsible
+ * for initializing and creating all CUDA resources that all work threads will
+ * use. The most common task that should be expected from an implementation of this
+ * class is creating a CUDA program and compiling the kernels used for its
+ * analytic type.
+ */
+class EAbstractAnalytic::CUDA : public QObject
+{
+   Q_OBJECT
+public:
+   class Worker;
+public:
+   /*!
+    * This interface creates and returns a new CUDA worker for the implementation's
+    * analytic type.
+    *
+    * @return Pointer to a new CUDA worker object.
+    */
+   virtual std::unique_ptr<EAbstractAnalytic::CUDA::Worker> makeWorker() = 0;
+   /*!
+    * This interface initializes all CUDA resources used by this object's
+    * implementation.
+    *
+    * @param context
+    */
+   virtual void initialize(::CUDA::Context* context) = 0;
+public:
+   explicit CUDA(EAbstractAnalytic* parent);
+};
+
+
+
+#endif

--- a/src/core/eabstractanalytic_cuda_worker.cpp
+++ b/src/core/eabstractanalytic_cuda_worker.cpp
@@ -1,0 +1,24 @@
+#include "eabstractanalytic_cuda_worker.h"
+#include "ace_settings.h"
+#include "edebug.h"
+
+
+
+//
+
+
+
+
+
+
+/*!
+ * Returns the total number of threads ACE uses to run CUDA workers in parallel.
+ *
+ * @return Total number of CUDA worker threads.
+ */
+int EAbstractAnalytic::CUDA::Worker::threadSize()
+{
+   EDEBUG_FUNC()
+
+   return Ace::Settings::instance().threadSize();
+}

--- a/src/core/eabstractanalytic_cuda_worker.h
+++ b/src/core/eabstractanalytic_cuda_worker.h
@@ -1,0 +1,35 @@
+#ifndef EABSTRACTANALYTIC_CUDA_WORKER_H
+#define EABSTRACTANALYTIC_CUDA_WORKER_H
+#include "eabstractanalytic_cuda.h"
+//
+
+
+
+/*!
+ * This represents a single CUDA worker for an analytic type that processes work
+ * blocks and returns result blocks using CUDA acceleration. Multiple instances
+ * of this class are used in parallel on separate threads so thread safety must
+ * always be considered for any code used by the the methods of any implementation
+ * of this class.
+ */
+class EAbstractAnalytic::CUDA::Worker : public QObject
+{
+   Q_OBJECT
+public:
+   /*!
+    * This interface reads in the given work block, executes the algorithms necessary
+    * to produce its results using CUDA acceleration, and saves those results in a
+    * new results block whose pointer is returned.
+    *
+    * @param block
+    *
+    * @return Pointer to results block produced from the given work block.
+    */
+   virtual std::unique_ptr<EAbstractAnalytic::Block> execute(const EAbstractAnalytic::Block* block) = 0;
+protected:
+   static int threadSize();
+};
+
+
+
+#endif

--- a/src/core/edebug.cpp
+++ b/src/core/edebug.cpp
@@ -666,6 +666,9 @@ EDebug& EDebug::operator<<(Ace::Analytic::AbstractMPI::Type value)
    case Ace::Analytic::AbstractMPI::OpenCL:
       *this << NoQuote << QStringLiteral("OpenCL") << Quote;
       break;
+   case Ace::Analytic::AbstractMPI::CUDA:
+      *this << NoQuote << QStringLiteral("CUDA") << Quote;
+      break;
    }
 
    // Return a reference to this object. 

--- a/src/example/core/core.pro
+++ b/src/example/core/core.pro
@@ -26,7 +26,10 @@ SOURCES += \
     mathtransform_block.cpp \
     mathtransform_opencl.cpp \
     mathtransform_opencl_kernel.cpp \
-    mathtransform_opencl_worker.cpp
+    mathtransform_opencl_worker.cpp \
+    mathtransform_cuda.cpp \
+    mathtransform_cuda_kernel.cpp \
+    mathtransform_cuda_worker.cpp
 
 HEADERS += \
     analyticfactory.h \
@@ -45,6 +48,9 @@ HEADERS += \
     mathtransform_block.h \
     mathtransform_opencl.h \
     mathtransform_opencl_kernel.h \
-    mathtransform_opencl_worker.h
+    mathtransform_opencl_worker.h \
+    mathtransform_cuda.h \
+    mathtransform_cuda_kernel.h \
+    mathtransform_cuda_worker.h
 
 QMAKE_CXXFLAGS += -Wno-ignored-attributes

--- a/src/example/core/mathtransform.cpp
+++ b/src/example/core/mathtransform.cpp
@@ -3,6 +3,7 @@
 #include "mathtransform_input.h"
 #include "mathtransform_serial.h"
 #include "mathtransform_opencl.h"
+#include "mathtransform_cuda.h"
 #include "dataframe_iterator.h"
 #include "core/elog.h"
 
@@ -161,6 +162,21 @@ EAbstractAnalytic::Serial* MathTransform::makeSerial()
 EAbstractAnalytic::OpenCL* MathTransform::makeOpenCL()
 {
    return new OpenCL(this);
+}
+
+
+
+
+
+
+/*!
+ * Implements the interface that makes a new CUDA object and returns its pointer. 
+ *
+ * @return Pointer to new CUDA object. 
+ */
+EAbstractAnalytic::CUDA* MathTransform::makeCUDA()
+{
+   return new CUDA(this);
 }
 
 

--- a/src/example/core/mathtransform.h
+++ b/src/example/core/mathtransform.h
@@ -21,6 +21,7 @@ public:
    class Block;
    class Serial;
    class OpenCL;
+   class CUDA;
    virtual int size() const override final;
    virtual std::unique_ptr<EAbstractAnalytic::Block> makeWork(int index) const override final;
    virtual std::unique_ptr<EAbstractAnalytic::Block> makeWork() const override final;
@@ -29,6 +30,7 @@ public:
    virtual EAbstractAnalytic::Input* makeInput() override final;
    virtual EAbstractAnalytic::Serial* makeSerial() override final;
    virtual EAbstractAnalytic::OpenCL* makeOpenCL() override final;
+   virtual EAbstractAnalytic::CUDA* makeCUDA() override final;
    virtual void initialize() override final;
    virtual void initializeOutputs() override final;
 private:

--- a/src/example/core/mathtransform_cuda.cpp
+++ b/src/example/core/mathtransform_cuda.cpp
@@ -1,0 +1,59 @@
+#include "mathtransform_cuda.h"
+#include "mathtransform_cuda_worker.h"
+
+
+
+using namespace std;
+//
+
+
+
+
+
+
+/*!
+ * Constructs a new CUDA object with the given math transform parent. 
+ *
+ * @param parent Pointer to the parent math transform analytic of this new CUDA 
+ *               object. 
+ */
+MathTransform::CUDA::CUDA(MathTransform* parent):
+   EAbstractAnalytic::CUDA(parent),
+   _base(parent)
+{}
+
+
+
+
+
+
+/*!
+ * Implements the interface that creates and returns a new CUDA worker for the 
+ * implementation's analytic type. 
+ *
+ * @return Pointer to a new CUDA worker object. 
+ */
+std::unique_ptr<EAbstractAnalytic::CUDA::Worker> MathTransform::CUDA::makeWorker()
+{
+   return unique_ptr<EAbstractAnalytic::CUDA::Worker>(new Worker(_base,this,_program));
+}
+
+
+
+
+
+
+/*!
+ * Implements the interface that initializes all CUDA resources used by this 
+ * object's implementation. 
+ *
+ * @param context The CUDA context to used to initialize all other CUDA 
+ *                resources. 
+ */
+void MathTransform::CUDA::initialize(::CUDA::Context* context)
+{
+   // Set this object's context pointer to the one given and then create this 
+   // object's CUDA program. 
+   _context = context;
+   _program = new ::CUDA::Program({":/cuda/mathtransform.cu"},this);
+}

--- a/src/example/core/mathtransform_cuda.h
+++ b/src/example/core/mathtransform_cuda.h
@@ -1,0 +1,38 @@
+#ifndef MATHTRANSFORM_CUDA_H
+#define MATHTRANSFORM_CUDA_H
+#include <core/cudaxx.h>
+#include "mathtransform.h"
+//
+
+
+
+/*!
+ * This implements the base CUDA class for its parent math transform analytic. 
+ */
+class MathTransform::CUDA : public EAbstractAnalytic::CUDA
+{
+   Q_OBJECT
+public:
+   class Kernel;
+   class Worker;
+   explicit CUDA(MathTransform* parent);
+   virtual std::unique_ptr<EAbstractAnalytic::CUDA::Worker> makeWorker() override final;
+   virtual void initialize(::CUDA::Context* context) override final;
+private:
+   /*!
+    * Pointer to this object's parent math transform analytic. 
+    */
+   MathTransform* _base;
+   /*!
+    * Pointer to this object's base CUDA context used to create all other resources. 
+    */
+   ::CUDA::Context* _context {nullptr};
+   /*!
+    * Pointer to this object's CUDA program. 
+    */
+   ::CUDA::Program* _program {nullptr};
+};
+
+
+
+#endif

--- a/src/example/core/mathtransform_cuda_kernel.cpp
+++ b/src/example/core/mathtransform_cuda_kernel.cpp
@@ -1,0 +1,64 @@
+#include "mathtransform_cuda_kernel.h"
+
+
+
+//
+
+
+
+
+
+
+/*!
+ * Constructs a new kernel object with the given CUDA program. 
+ *
+ * @param program Pointer to the CUDA program used to build this new kernel's 
+ *                CUDA resource. 
+ */
+MathTransform::CUDA::Kernel::Kernel(::CUDA::Program* program):
+   ::CUDA::Kernel(program,"mathTransform")
+{}
+
+
+
+
+
+
+/*!
+ * Begins execution of this kernel object's CUDA kernel using the given CUDA 
+ * stream and kernel arguments, returning the CUDA event associated with 
+ * the kernel execution. 
+ *
+ * @param stream The CUDA stream this kernel is executed on. 
+ *
+ * @param buffer The CUDA memory buffer where a row is stored and will 
+ *               be transformed by this kernel execution. 
+ *
+ * @param type The mathematical operation type that will be used for the transform. 
+ *
+ * @param amount The amount that will be used for the mathematical transform. 
+ *
+ * @return CUDA event associated with this kernel's execution. 
+ */
+::CUDA::Event MathTransform::CUDA::Kernel::execute(const ::CUDA::Stream& stream, ::CUDA::Buffer<float>* buffer, Operation type, int amount)
+{
+   // Set the arguments this CUDA kernel requires. This includes the global memory 
+   // buffer where the row is held, the local memory buffer, the operation type, 
+   // and the amount.
+   setBuffer(GlobalBuffer,buffer);
+   setArgument(GlobalSize,buffer->size());
+   setArgument(Type,static_cast<int>(type));
+   setArgument(Amount,amount);
+
+   // Set the work sizes. The global work size is determined by the row size, but
+   // it must also be a multiple of the local work size, so it is rounded up
+   // accordingly.
+   int localWorkSize = 1;
+   int workgroupSize = (buffer->size() + localWorkSize - 1) / localWorkSize;
+
+   setSizes(workgroupSize * localWorkSize, localWorkSize);
+
+   // Execute this object's CUDA kernel with the given stream, returning its 
+   // generated CUDA event. 
+   return ::CUDA::Kernel::execute(stream);
+}

--- a/src/example/core/mathtransform_cuda_kernel.h
+++ b/src/example/core/mathtransform_cuda_kernel.h
@@ -1,0 +1,45 @@
+#ifndef MATHTRANSFORM_CUDA_KERNEL_H
+#define MATHTRANSFORM_CUDA_KERNEL_H
+#include "mathtransform_cuda.h"
+//
+
+
+
+/*!
+ * This is the primary and sole CUDA kernel used for the math transform analytic 
+ * type. This kernel takes one integer, transforms it, and returns the result. This 
+ * is a superficial and very inefficient implementation of CUDA kernels in 
+ * general and should only be used as an example of how to use ACE. 
+ */
+class MathTransform::CUDA::Kernel : public ::CUDA::Kernel
+{
+public:
+   /*!
+    * Defines the arguments passed to the CUDA kernel. 
+    */
+   enum Argument
+   {
+      /*!
+       * Defines the global buffer argument. 
+       */
+      GlobalBuffer
+      /*!
+       * Defines the global size argument. 
+       */
+      ,GlobalSize
+      /*!
+       * Defines the operation type argument. 
+       */
+      ,Type
+      /*!
+       * Defines the amount argument. 
+       */
+      ,Amount
+   };
+   Kernel(::CUDA::Program* program);
+   ::CUDA::Event execute(const ::CUDA::Stream& stream, ::CUDA::Buffer<float>* buffer, Operation type, int amount);
+};
+
+
+
+#endif

--- a/src/example/core/mathtransform_cuda_worker.cpp
+++ b/src/example/core/mathtransform_cuda_worker.cpp
@@ -1,0 +1,76 @@
+#include "mathtransform_cuda_worker.h"
+#include "mathtransform_block.h"
+#include "core/elog.h"
+
+
+
+using namespace std;
+//
+
+
+
+
+
+
+/*!
+ * Constructs a new CUDA worker with the given math transform base and CUDA program.
+ *
+ * @param base Pointer to the base math transform analytic used to get argument
+ *             values from.
+ *
+ * @param baseCuda Pointer to the base CUDA class used to access CUDA context.
+ *
+ * @param program Pointer to CUDA program used to create this new worker's kernel
+ *                object.
+ */
+MathTransform::CUDA::Worker::Worker(MathTransform* base, MathTransform::CUDA* baseCuda, ::CUDA::Program* program):
+   _base(base),
+   _baseCuda(baseCuda),
+   _kernel(program),
+   _buffer(base->_in->columnSize())
+{}
+
+
+
+
+
+
+/*!
+ * Implements the interface that reads in the given work block, executes the 
+ * algorithms necessary to produce its results using CUDA acceleration, and saves
+ * those results in a new results block whose pointer is returned.
+ *
+ * @param block Pointer to work block used to create a results block.
+ *
+ * @return Pointer to results block produced from the given work block.
+ */
+std::unique_ptr<EAbstractAnalytic::Block> MathTransform::CUDA::Worker::execute(const EAbstractAnalytic::Block* block)
+{
+   if ( ELog::isActive() )
+   {
+      ELog() << tr("Executing(CUDA) work index %1.").arg(block->index());
+   }
+   // Cast the given generic work block to this analytic type work block _valid_. 
+   const MathTransform::Block* valid {block->cast<const MathTransform::Block>()};
+
+   // Bind the base class's CUDA context to the worker's thread.
+   _baseCuda->_context->setCurrent();
+
+   // Write the row data from _valid_ and wait for writing to finish.
+   for ( int i = 0; i < valid->_data.size(); i++ )
+   {
+      _buffer[i] = valid->_data[i];
+   }
+   _buffer.write(_stream).wait();
+
+   // Execute this object's kernel with its row buffer, this base analytic 
+   // object's operation type, and its amount. Wait for the kernel to finish. 
+   _kernel.execute(_stream,&_buffer,_base->_type,_base->_amount).wait();
+
+   // Read the row data from the buffer and wait for reading to finish.
+   _buffer.read(_stream).wait();
+
+   // Create a new result block with the given work block's index and 
+   // row data, returning its pointer. 
+   return unique_ptr<EAbstractAnalytic::Block>(new MathTransform::Block(block->index(),_buffer.size(),_buffer.hostData()));
+}

--- a/src/example/core/mathtransform_cuda_worker.h
+++ b/src/example/core/mathtransform_cuda_worker.h
@@ -1,0 +1,40 @@
+#ifndef MATHTRANSFORM_CUDA_WORKER_H
+#define MATHTRANSFORM_CUDA_WORKER_H
+#include "mathtransform_cuda.h"
+#include "mathtransform_cuda_kernel.h"
+//
+
+
+
+/*!
+ * This implements the CUDA worker class for its parent math transform analytic. 
+ */
+class MathTransform::CUDA::Worker : public EAbstractAnalytic::CUDA::Worker
+{
+   Q_OBJECT
+public:
+   explicit Worker(MathTransform* base, MathTransform::CUDA* baseCuda, ::CUDA::Program* program);
+   virtual std::unique_ptr<EAbstractAnalytic::Block> execute(const EAbstractAnalytic::Block* block) override final;
+private:
+   /*!
+    * Pointer to this worker's math transform analytic. 
+    */
+   MathTransform* _base;
+   MathTransform::CUDA* _baseCuda;
+   /*!
+    * Unique stream object for this worker.
+    */
+   ::CUDA::Stream _stream;
+   /*!
+    * Unique kernel object for this worker.
+    */
+   CUDA::Kernel _kernel;
+   /*!
+    * Unique row buffer for this worker.
+    */
+   ::CUDA::Buffer<float> _buffer;
+};
+
+
+
+#endif

--- a/src/example/cuda/mathtransform.cu
+++ b/src/example/cuda/mathtransform.cu
@@ -1,0 +1,39 @@
+#define ADDITION 0
+#define SUBTRACTION 1
+#define MULTIPLICATION 2
+#define DIVISION 3
+
+
+
+
+
+
+__global__ void mathTransform(float* globalBuffer, int globalSize, int type, int amount)
+{
+   __shared__ float localValue;
+
+   int i = blockIdx.x * blockDim.x + threadIdx.x;
+
+   if ( i >= globalSize )
+   {
+      return;
+   }
+
+   localValue = globalBuffer[i];
+   switch (type)
+   {
+   case ADDITION:
+      localValue += amount;
+      break;
+   case SUBTRACTION:
+      localValue -= amount;
+      break;
+   case MULTIPLICATION:
+      localValue *= amount;
+      break;
+   case DIVISION:
+      localValue /= amount;
+      break;
+   }
+   globalBuffer[i] = localValue;
+}

--- a/src/example/example.pri
+++ b/src/example/example.pri
@@ -1,7 +1,7 @@
 
 isEmpty(MPICXX) { MPICXX = "yes" }
 
-LIBS += -L$${PWD}/../../build/libs -laceexcore -lacecore -lOpenCL -lmpi
+LIBS += -L$${PWD}/../../build/libs -laceexcore -lacecore -L$${CUDADIR}/lib64 -lcuda -lnvrtc -lOpenCL -lmpi
 equals(MPICXX,"yes") { LIBS += -lmpi_cxx }
 
 INCLUDEPATH += $${PWD}/../ $${PWD}/core/

--- a/src/example/resources.qrc
+++ b/src/example/resources.qrc
@@ -1,5 +1,6 @@
 <RCC>
     <qresource prefix="/">
+        <file>cuda/mathtransform.cu</file>
         <file>opencl/mathtransform.cl</file>
     </qresource>
 </RCC>

--- a/src/gui/ace_settingsdialog.h
+++ b/src/gui/ace_settingsdialog.h
@@ -25,20 +25,25 @@ namespace Ace
    private slots:
       void okClicked();
       void applyClicked();
-      void currentPlatformChanged(int index);
+      void currentOpenCLPlatformChanged(int index);
    private:
       QLayout* setupWarning();
       QLayout* createForm();
       QLayout* createButtons();
+      QLayout* createCUDA();
       QLayout* createOpenCL();
+      /*!
+       * The combo box for this dialog used to select the CUDA device.
+       */
+      QComboBox* _cudaDeviceCombo;
       /*!
        * The combo box for this dialog used to select the OpenCL platform. 
        */
-      QComboBox* _platformCombo;
+      QComboBox* _openclPlatformCombo;
       /*!
        * The combo box for this dialog used to select the OpenCL device. 
        */
-      QComboBox* _deviceCombo;
+      QComboBox* _openclDeviceCombo;
       /*!
        * The spin box for this dialog used to edit the thread size setting. 
        */


### PR DESCRIPTION
The CUDA interface is pretty similar to the OpenCL interface, except in some cases it is slightly simpler.

Here's an expanded script to test cuda / opencl / serial side-by-side:
```
#!/bin/bash

# parse command-line arguments
if [[ $# != 2 ]]; then
	echo "usage: $0 <mode> <infile>"
	exit -1
fi

MODE="$1"
IN_TXTFILE="$2"
IN_TABFILE="data/a.tab"
OUT_TABFILE="data/b.tab"
OUT_TXTFILE="data/b.txt"

# adjust aceex settings
aceex settings set logging off

# import dataframe
aceex run import --in $IN_TXTFILE --out $IN_TABFILE

# math transform
if [[ $MODE == "cuda" ]]; then
	aceex settings set cuda 0
	aceex settings set opencl none
	aceex run transform \
		--in $IN_TABFILE \
		--out $OUT_TABFILE \
		--type multiplication \
		--amount 10
elif [[ $MODE == "opencl" ]]; then
	aceex settings set cuda none
	aceex settings set opencl 0:0
	aceex run transform \
		--in $IN_TABFILE \
		--out $OUT_TABFILE \
		--type multiplication \
		--amount 10
elif [[ $MODE == "serial" ]]; then
	aceex settings set cuda none
	aceex settings set opencl none
	aceex run transform \
		--in $IN_TABFILE \
		--out $OUT_TABFILE \
		--type multiplication \
		--amount 10
else
	echo "error: invalid mode '$MODE'"
	exit -1
fi

# export dataframe
aceex run export --in $OUT_TABFILE --out $OUT_TXTFILE
```