### PR TITLE
Rename console to CLI

### DIFF
--- a/src/cli/ace_helprun.cpp
+++ b/src/cli/ace_helprun.cpp
@@ -543,7 +543,7 @@ void HelpRun::settingsHelp()
          stream << "Command: " << _runName << " settings [set|list|] ...\n"
                 << "Executes the settings command that accesses the persistent settings of this\n"
                 << "application. These settings are persistent across all instances of this\n"
-                << "application in both the console and GUI version. The basic command with no sub\n"
+                << "application in both the CLI and GUI version. The basic command with no sub\n"
                 << "arguments will simply print out the current value of all settings. The set sub\n"
                 << "command will set a specific setting to a new value. The list sub command will\n"
                 << "list valid values for certain settings.\n\n"

--- a/src/cli/ace_helprun.h
+++ b/src/cli/ace_helprun.h
@@ -13,7 +13,7 @@ class QTextStream;
 namespace Ace
 {
    /*!
-    * This handles the help command for the console program of ACE. This class only
+    * This handles the help command for the CLI program of ACE. This class only
     * requires command arguments to be passed to it. This parses a assumed help
     * command and outputs the appropriate help text based off the given command
     * arguments. If there are no command arguments the root help text is displayed.

--- a/src/cli/ace_run.h
+++ b/src/cli/ace_run.h
@@ -14,7 +14,7 @@
 namespace Ace
 {
    /*!
-    * This handles all run commands for the console program of ACE. These commands
+    * This handles all run commands for the CLI program of ACE. These commands
     * include run, chunk run, and merge. If MPI is being used it is auto detected
     * by this class. The main responsibility of this class is to initialize an
     * analytic manager and start its process of running the analytic. This class

--- a/src/cli/ace_settingsrun.h
+++ b/src/cli/ace_settingsrun.h
@@ -12,7 +12,7 @@
 namespace Ace
 {
    /*!
-    * This handles the settings command for the console program of ACE. This class
+    * This handles the settings command for the CLI program of ACE. This class
     * only requires command argument be passed to it because it does not use
     * options at all. The majority of this class deals with parsing user input and
     * verifying its validity along with taking the current settings of ACE and

--- a/src/cli/cli.pro
+++ b/src/cli/cli.pro
@@ -2,7 +2,7 @@
 include(../ACE.pri)
 
 DESTDIR = $$PWD/../../build/libs/
-TARGET = aceconsole
+TARGET = acecli
 
 TEMPLATE = lib
 
@@ -26,6 +26,6 @@ HEADERS += \
 isEmpty(PREFIX) { PREFIX = /usr/local }
 library.path = $${PREFIX}/lib
 library.extra = cp -fd $${OUT_PWD}/../libs/lib$${TARGET}.so* $${PREFIX}/lib/
-includes.path = $${PREFIX}/include/ace/console
+includes.path = $${PREFIX}/include/ace/cli
 includes.files = $${PWD}/*.h
 INSTALLS += library includes

--- a/src/cli/eapplication.h
+++ b/src/cli/eapplication.h
@@ -9,7 +9,7 @@
 
 
 /*!
- * This is the console application instantiated and executed by a program using
+ * This is the CLI application instantiated and executed by a program using
  * ACE. This class initializes the ACE system with the given application
  * information and factories, along with parsing the command line and
  * determining which command the user has given. If the command given is a dump

--- a/src/core/eexception.h
+++ b/src/core/eexception.h
@@ -14,7 +14,7 @@
  * function name, and line fields. This class is thrown as an exception on any
  * ACE error. If the program using ACE does not catch a thrown error ACE itself
  * will handle it, either reporting it to the user without crashing if in GUI
- * mode or reporting it to the user and exiting if in console mode.
+ * mode or reporting it to the user and exiting if in CLI mode.
  */
 class EException
 {

--- a/src/example/cli/cli.pro
+++ b/src/example/cli/cli.pro
@@ -4,7 +4,7 @@ include(../example.pri)
 
 TARGET = aceex
 
-LIBS += -laceconsole
+LIBS += -lacecli
 
 SOURCES += \
     ../main.cpp \


### PR DESCRIPTION
Not sure if this was your intention or not, but there were a few things that didn't get renamed, in particular the library files and header files in the build directory. As a result I was actually still able to build KINC without errors. But in case you didn't mean to do that here are a few more changes that I found with my handy project search tool.