### PR TITLE
Added setAttribute() to CUDA::Kernel

### DIFF
--- a/src/core/cuda_kernel.cpp
+++ b/src/core/cuda_kernel.cpp
@@ -109,6 +109,31 @@ int Kernel::getAttribute(CUfunction_attribute attribute) const
 
 
 /*!
+ * Sets an attribute of this CUDA kernel. Refer to the CUDA Toolkit Documentation
+ * for more information on the available kernel attributes.
+ *
+ * @param attribute Enumerated value for a CUDA kernel attribute.
+ *
+ * @param value The value to set the given attribute to.
+ */
+void Kernel::setAttribute(CUfunction_attribute attribute, int value)
+{
+   // Set the value of the given kernel attribute. If this command fails then
+   // throw an exception.
+   CUresult result = cuFuncSetAttribute(_kernel, attribute, value);
+   if ( result != CUDA_SUCCESS )
+   {
+      E_MAKE_EXCEPTION(e);
+      throwError(&e,result);
+   }
+}
+
+
+
+
+
+
+/*!
  * Sets the global and local work sizes used for parallel execution of this kernel
  * object. Each work size can be one-, two-, or three-dimensional.
  *

--- a/src/core/cuda_kernel.h
+++ b/src/core/cuda_kernel.h
@@ -26,6 +26,7 @@ namespace CUDA
       Event execute(const Stream& stream = Stream::getDefaultStream());
    protected:
       int getAttribute(CUfunction_attribute attribute) const;
+      void setAttribute(CUfunction_attribute attribute, int value);
       void setSizes(dim3 globalSize, dim3 localSize);
       template<class T> void setArgument(int index, T value);
       template<class T> void setBuffer(int index, Buffer<T>* buffer);


### PR DESCRIPTION
Adds a wrapper method to `cuFuncSetAttribute()`, which is helpful for experimenting with some low-level device settings. In modern NVIDIA GPUs, the shared memory and L1 cache share the same hardware and you can control how much is alloted for each type. This method allows me to experiment with devoting all of the memory to L1 cache since the GMM kernel doesn't use shared memory.