### PR TITLE
CUDA fix

### DIFF
--- a/src/core/cuda_kernel.cpp
+++ b/src/core/cuda_kernel.cpp
@@ -172,7 +172,7 @@ void Kernel::setSharedMemory(unsigned int size)
  *
  * @param blockSize Number of threads per block.
  */
-int Kernel::getMaxActiveBlocksPerMultiprocessor(int blockSize)
+int Kernel::getMaxActiveBlocksPerMultiprocessor(int blockSize) const
 {
    int numBlocks;
    CUresult result = cuOccupancyMaxActiveBlocksPerMultiprocessor(&numBlocks, _kernel, blockSize, _sharedMemBytes);

--- a/src/core/cuda_kernel.cpp
+++ b/src/core/cuda_kernel.cpp
@@ -146,3 +146,41 @@ void Kernel::setSizes(dim3 globalSize, dim3 localSize)
    _gridDim = globalSize;
    _blockDim = localSize;
 }
+
+
+
+
+
+
+/*!
+ * Sets the amount of dynamic shared memory per thread block to allocate.
+ *
+ * @param size Dynamic shared memory size per thread block in bytes.
+ */
+void Kernel::setSharedMemory(unsigned int size)
+{
+   _sharedMemBytes = size;
+}
+
+
+
+
+
+
+/*!
+ * Get the occupancy of this kernel for a given block size.
+ *
+ * @param blockSize Number of threads per block.
+ */
+int Kernel::getMaxActiveBlocksPerMultiprocessor(int blockSize)
+{
+   int numBlocks;
+   CUresult result = cuOccupancyMaxActiveBlocksPerMultiprocessor(&numBlocks, _kernel, blockSize, _sharedMemBytes);
+   if ( result != CUDA_SUCCESS )
+   {
+      E_MAKE_EXCEPTION(e);
+      throwError(&e,result);
+   }
+
+   return numBlocks;
+}

--- a/src/core/cuda_kernel.h
+++ b/src/core/cuda_kernel.h
@@ -24,6 +24,7 @@ namespace CUDA
       Kernel(Program* program, const QString& name);
       virtual ~Kernel() {};
       Event execute(const Stream& stream = Stream::getDefaultStream());
+      int getMaxActiveBlocksPerMultiprocessor(int blockSize) const;
    protected:
       int getAttribute(CUfunction_attribute attribute) const;
       void setAttribute(CUfunction_attribute attribute, int value);
@@ -31,7 +32,6 @@ namespace CUDA
       template<class T> void setArgument(int index, T value);
       template<class T> void setBuffer(int index, Buffer<T>* buffer);
       void setSharedMemory(unsigned int size);
-      int getMaxActiveBlocksPerMultiprocessor(int blockSize);
    private:
       /*!
        * The CUDA kernel of this object.

--- a/src/core/cuda_kernel.h
+++ b/src/core/cuda_kernel.h
@@ -30,7 +30,8 @@ namespace CUDA
       void setSizes(dim3 globalSize, dim3 localSize);
       template<class T> void setArgument(int index, T value);
       template<class T> void setBuffer(int index, Buffer<T>* buffer);
-      void setSharedMemory(unsigned int size) { _sharedMemBytes = size; }
+      void setSharedMemory(unsigned int size);
+      int getMaxActiveBlocksPerMultiprocessor(int blockSize);
    private:
       /*!
        * The CUDA kernel of this object.

--- a/src/core/cuda_kernel.h
+++ b/src/core/cuda_kernel.h
@@ -24,7 +24,6 @@ namespace CUDA
       Kernel(Program* program, const QString& name);
       virtual ~Kernel() {};
       Event execute(const Stream& stream = Stream::getDefaultStream());
-      int getMaxActiveBlocksPerMultiprocessor(int blockSize) const;
    protected:
       int getAttribute(CUfunction_attribute attribute) const;
       void setAttribute(CUfunction_attribute attribute, int value);
@@ -32,6 +31,7 @@ namespace CUDA
       template<class T> void setArgument(int index, T value);
       template<class T> void setBuffer(int index, Buffer<T>* buffer);
       void setSharedMemory(unsigned int size);
+      int getMaxActiveBlocksPerMultiprocessor(int blockSize) const;
    private:
       /*!
        * The CUDA kernel of this object.

--- a/src/example/core/mathtransform_cuda_kernel.cpp
+++ b/src/example/core/mathtransform_cuda_kernel.cpp
@@ -53,10 +53,10 @@ MathTransform::CUDA::Kernel::Kernel(::CUDA::Program* program):
    // Set the work sizes. The global work size is determined by the row size, but
    // it must also be a multiple of the local work size, so it is rounded up
    // accordingly.
-   int localWorkSize = 1;
-   int workgroupSize = (buffer->size() + localWorkSize - 1) / localWorkSize;
+   int blockSize = 1;
+   int gridSize = (buffer->size() + blockSize - 1) / blockSize;
 
-   setSizes(workgroupSize * localWorkSize, localWorkSize);
+   setSizes(gridSize, blockSize);
 
    // Execute this object's CUDA kernel with the given stream, returning its 
    // generated CUDA event. 


### PR DESCRIPTION
Just a small fix I forgot to add a while ago. In OpenCL the global work size is the number of all work items, but in CUDA the grid size is the number of all thread blocks (workgroups in OpenCL). When I added the CUDA example (which was adapted from the OpenCL example) I forgot to make this change. Doesn't cause any errors but CUDA just launches a bunch of extra threads that immediately exit. So I'm fixing this for future ACE users.

Funny story, for the longest time the KINC CUDA kernel was always just slightly slower than the OpenCL kernel... then I finally fixed this in the KINC code and then the CUDA version was slightly faster... as it should be.